### PR TITLE
changed all deprecated methods in 4B

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -515,14 +515,14 @@
     "                                                 CompleteMeasFitter, \n",
     "                                                 MeasurementFilter)\n",
     "\n",
-    "IBMQ.load_accounts()\n",
+    "IBMQ.load_account()\n",
     "\n",
-    "backend = IBMQ.get_backend('ibmqx2') # calibrate using real hardware\n",
+    "backend = IBMQ.get_provider().get_backend('ibmqx2') # calibrate using real hardware\n",
     "layout = [2,3,0,4]\n",
     "chip_qubits = 5\n",
     "\n",
     "# Transpiled circuit for the real hardware\n",
-    "qc_qa_c = transpile(qc, backend=ibmq_backend, initial_layout=layout)"
+    "qc_qa_cx = transpile(qc, backend=backend, initial_layout=layout)"
    ]
   },
   {
@@ -541,11 +541,12 @@
     "meas_cals, state_labels = complete_meas_cal(qubit_list=layout, qr=QuantumRegister(chip_qubits))\n",
     "\n",
     "#  The following are the circuits that were obtained after replacing each CNOT by 1, 3 and 5 CNOTs respectively\n",
-    "circuits = [qc_qa_c, qc_qa_3cx, qc_qa_5cx]\n",
+    "circuits = [qc_qa_cx, qc_qa_3cx, qc_qa_5cx]\n",
     "\n",
     "qcs = meas_cals + circuits\n",
-    "\n",
-    "job = qiskit.execute(meas_cals + circuits, backend=backend, shots=shots, optimization_level=None)"
+    "shots = 10\n",
+    "job = execute(qcs, backend=backend, shots=shots, optimization_level=None)\n",
+    "result = job.result()"
    ]
   },
   {


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)

Fixes some of #309 but not all

## What Changes Were Made?
Deprecated qiskit functions were replaced by newer once:
IBMQ.load_account()
IBMQ.get_provider().get_backend('ibmqx2')

shots were set to 10 and result added.

## How Was This Tested?
It is running (no errors anymore, which was the goal of the changes), but gives wrong results as the constant t and m are not defined (rest of the issue of #309).

Please provide any screenshots if applicable.

## Anything Else We Should Know 
