### PR TITLE
Fixing a typo in measurement-error-mitigation

### DIFF
--- a/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
+++ b/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
@@ -169,7 +169,7 @@
     "\n",
     "Here the first element is that for `'00'`, the next is that for `'01'`, and so on.\n",
     "\n",
-    "The information gathered from the basis states $\\left|00\\right\\rangle$, $\\left|01\\right\\rangle$, $\\left|10\\right\\rangle$ and $\\left|11\\right\\rangle$ can then be used to define a matrix, which rotates from an ideal set of counts to one affected by measurement noise. This is done by simply taking the counts dictionary for $\\left|00\\right\\rangle$, normalizing it it so that all elements sum to one, and then using it as the first column of the matrix. The next column is similarly defined by the counts dictionary obtained for $\\left|00\\right\\rangle$, and so on. \n",
+    "The information gathered from the basis states $\\left|00\\right\\rangle$, $\\left|01\\right\\rangle$, $\\left|10\\right\\rangle$ and $\\left|11\\right\\rangle$ can then be used to define a matrix, which rotates from an ideal set of counts to one affected by measurement noise. This is done by simply taking the counts dictionary for $\\left|00\\right\\rangle$, normalizing it it so that all elements sum to one, and then using it as the first column of the matrix. The next column is similarly defined by the counts dictionary obtained for $\\left|01\\right\\rangle$, and so on. \n",
     "\n",
     "There will be statistical variations each time the circuit for each basis state is run. In the following, we will use the data obtained when this section was written, which was as follows.\n",
     "\n",
@@ -435,14 +435,7 @@
       "c0_0: ═════════╩══╬═\n",
       "                  ║ \n",
       "c0_1: ════════════╩═\n",
-      "                    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "                    \n",
       "\n",
       "Circuit mcalcal_11\n",
       "      ┌───┐ ░ ┌─┐   \n",
@@ -1793,7 +1786,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION

## Description of Issue (if Applicable)
Significant typo in 5.2 Measurement Error Mitigation #464
Fixes #464

## What Changes Were Made?

|00> to |01> in the line -
The information gathered from the basis states  ||00⟩ ,  ||01⟩ ,  ||10⟩  and  ||11⟩  can then be used to define a matrix, which rotates from an ideal set of counts to one affected by measurement noise. This is done by simply taking the counts dictionary for  ||00⟩ , normalizing it so that all elements sum to one, and then using it as the first column of the matrix. The next column is similarly defined by the counts dictionary obtained for  **||01⟩** , and so on.

