### PR TITLE
Fixed links pointing to phase estimation and Fourier transform sections

### DIFF
--- a/content/ch-algorithms/shor.ipynb
+++ b/content/ch-algorithms/shor.ipynb
@@ -1245,7 +1245,7 @@
    "source": [
     "## 2. The Solution\n",
     "\n",
-    "Shor’s solution was to use [quantum phase estimation](./quantum-phase-estimation.ipynb) on the unitary operator:\n",
+    "Shor’s solution was to use [quantum phase estimation](https://qiskit.org/textbook/ch-algorithms/quantum-phase-estimation.html) on the unitary operator:\n",
     "\n",
     "$$ U|y\\rangle \\equiv |ay \\bmod N \\rangle $$\n",
     "\n",
@@ -2550,7 +2550,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also provide the circuit for the inverse QFT (you can read more about this in the [quantum Fourier transform chapter](./quantum-fourier-transform.ipynb#generalqft)):"
+    "We also provide the circuit for the inverse QFT (you can read more about this in the [quantum Fourier transform chapter](https://qiskit.org/textbook/ch-algorithms/quantum-fourier-transform.html#generalqft):"
    ]
   },
   {


### PR DESCRIPTION
## Description of Issue (if Applicable)
Links to the phase estimation and Fourier transform sections were pointing to their respective python notebooks so they were not working on the textbook website.

## What Changes Were Made?
Replaced the links so the point to the right html sections.
