### PR TITLE
add case-for-quantum to TOC

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -53,6 +53,8 @@
       url : /ch-states/representing-qubit-states
     - title: Single Qubit Gates
       url: /ch-states/single-qubit-gates
+    - title: The Case for Quantum
+      url: /ch-states/case-for-quantum
 
 - title: Multiple Qubits and Entanglement
   url: /ch-gates/introduction.html


### PR DESCRIPTION

This chapter is ready but is not currently showing on the site. This will add the chapter to the table of contents, which will publish the chapter.