### PR TITLE
Fix maxcut computation from samples in qaoa notebook

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -3,6 +3,16 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Solving-combinatorial-optimization-problems-using-QAOA\" data-toc-modified-id=\"Solving-combinatorial-optimization-problems-using-QAOA-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Solving combinatorial optimization problems using QAOA</a></span><ul class=\"toc-item\"><li><span><a href=\"#Contents\" data-toc-modified-id=\"Contents-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>Contents</a></span></li><li><span><a href=\"#1.-Introduction-\" data-toc-modified-id=\"1.-Introduction--1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>1. Introduction <a id=\"introduction\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#1.1-Diagonal-Hamiltonians\" data-toc-modified-id=\"1.1-Diagonal-Hamiltonians-1.2.1\"><span class=\"toc-item-num\">1.2.1&nbsp;&nbsp;</span>1.1 Diagonal Hamiltonians</a></span></li></ul></li><li><span><a href=\"#2-Examples:-\" data-toc-modified-id=\"2-Examples:--1.3\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>2 Examples: <a id=\"examples\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#2.1-(weighted)-$MAXCUT$\" data-toc-modified-id=\"2.1-(weighted)-$MAXCUT$-1.3.1\"><span class=\"toc-item-num\">1.3.1&nbsp;&nbsp;</span>2.1 (weighted) $MAXCUT$</a></span></li><li><span><a href=\"#2.2-Constraint-satisfaction-problems-and-$MAX-\\;-3-SAT$.\" data-toc-modified-id=\"2.2-Constraint-satisfaction-problems-and-$MAX-\\;-3-SAT$.-1.3.2\"><span class=\"toc-item-num\">1.3.2&nbsp;&nbsp;</span>2.2 Constraint satisfaction problems and $MAX \\; 3-SAT$.</a></span></li></ul></li><li><span><a href=\"#3.-Approximate-optimization-algorithms-\" data-toc-modified-id=\"3.-Approximate-optimization-algorithms--1.4\"><span class=\"toc-item-num\">1.4&nbsp;&nbsp;</span>3. Approximate optimization algorithms <a id=\"approximateOPT\"></a></a></span></li><li><span><a href=\"#4.-The-QAOA-algorithm-\" data-toc-modified-id=\"4.-The-QAOA-algorithm--1.5\"><span class=\"toc-item-num\">1.5&nbsp;&nbsp;</span>4. The QAOA algorithm <a id=\"QAOA\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#4.1-Overview:\" data-toc-modified-id=\"4.1-Overview:-1.5.1\"><span class=\"toc-item-num\">1.5.1&nbsp;&nbsp;</span>4.1 Overview:</a></span></li><li><span><a href=\"#4.2-The-components-of-the-QAOA-algorithm.\" data-toc-modified-id=\"4.2-The-components-of-the-QAOA-algorithm.-1.5.2\"><span class=\"toc-item-num\">1.5.2&nbsp;&nbsp;</span>4.2 The components of the QAOA algorithm.</a></span></li><li><span><a href=\"#4.2.1-The-QAOA-trial-state-\" data-toc-modified-id=\"4.2.1-The-QAOA-trial-state--1.5.3\"><span class=\"toc-item-num\">1.5.3&nbsp;&nbsp;</span>4.2.1 The QAOA trial state <a id=\"section_421\"></a></a></span></li><li><span><a href=\"#4.2.2-Computing-the-expectation-value-\" data-toc-modified-id=\"4.2.2-Computing-the-expectation-value--1.5.4\"><span class=\"toc-item-num\">1.5.4&nbsp;&nbsp;</span>4.2.2 Computing the expectation value <a id=\"section_422\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#Classical-evaluation\" data-toc-modified-id=\"Classical-evaluation-1.5.4.1\"><span class=\"toc-item-num\">1.5.4.1&nbsp;&nbsp;</span>Classical evaluation</a></span></li><li><span><a href=\"#Evaluation-on-a-quantum-computer\" data-toc-modified-id=\"Evaluation-on-a-quantum-computer-1.5.4.2\"><span class=\"toc-item-num\">1.5.4.2&nbsp;&nbsp;</span>Evaluation on a quantum computer</a></span></li></ul></li><li><span><a href=\"#4.3.3-Obtaining-a-solution-with-a-given-approximation-ratio-with-high-probability\" data-toc-modified-id=\"4.3.3-Obtaining-a-solution-with-a-given-approximation-ratio-with-high-probability-1.5.5\"><span class=\"toc-item-num\">1.5.5&nbsp;&nbsp;</span>4.3.3 Obtaining a solution with a given approximation ratio with high probability</a></span></li></ul></li><li><span><a href=\"#5.-Qiskit-Implementation\" data-toc-modified-id=\"5.-Qiskit-Implementation-1.6\"><span class=\"toc-item-num\">1.6&nbsp;&nbsp;</span>5. Qiskit Implementation<a id=\"implementation\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#5.1-Problem-definition\" data-toc-modified-id=\"5.1-Problem-definition-1.6.1\"><span class=\"toc-item-num\">1.6.1&nbsp;&nbsp;</span>5.1 Problem definition</a></span></li><li><span><a href=\"#5.2-Optimal-trial-state-parameters\" data-toc-modified-id=\"5.2-Optimal-trial-state-parameters-1.6.2\"><span class=\"toc-item-num\">1.6.2&nbsp;&nbsp;</span>5.2 Optimal trial state parameters<a id=\"implementation_sec52\"></a></a></span></li><li><span><a href=\"#5.3-Quantum-circuit\" data-toc-modified-id=\"5.3-Quantum-circuit-1.6.3\"><span class=\"toc-item-num\">1.6.3&nbsp;&nbsp;</span>5.3 Quantum circuit<a id=\"implementation_sec53\"></a></a></span></li><li><span><a href=\"#5.4--Cost-function-evaluation\" data-toc-modified-id=\"5.4--Cost-function-evaluation-1.6.4\"><span class=\"toc-item-num\">1.6.4&nbsp;&nbsp;</span>5.4  Cost function evaluation<a id=\"implementation_sec54\"></a></a></span></li></ul></li><li><span><a href=\"#5a.-Running-QAOA-on-a-simulator\" data-toc-modified-id=\"5a.-Running-QAOA-on-a-simulator-1.7\"><span class=\"toc-item-num\">1.7&nbsp;&nbsp;</span>5a. Running QAOA on a simulator<a id=\"implementationsim\"></a></a></span><ul class=\"toc-item\"><li><ul class=\"toc-item\"><li><span><a href=\"#Evaluate-the-date-from-the-simulation\" data-toc-modified-id=\"Evaluate-the-date-from-the-simulation-1.7.0.1\"><span class=\"toc-item-num\">1.7.0.1&nbsp;&nbsp;</span>Evaluate the date from the simulation</a></span></li></ul></li></ul></li><li><span><a href=\"#5b.-Running-QAOA-on-a-real-quantum-device\" data-toc-modified-id=\"5b.-Running-QAOA-on-a-real-quantum-device-1.8\"><span class=\"toc-item-num\">1.8&nbsp;&nbsp;</span>5b. Running QAOA on a real quantum device<a id=\"implementationdev\"></a></a></span><ul class=\"toc-item\"><li><ul class=\"toc-item\"><li><span><a href=\"#Evaluate-the-data-from-the-experiment\" data-toc-modified-id=\"Evaluate-the-data-from-the-experiment-1.8.0.1\"><span class=\"toc-item-num\">1.8.0.1&nbsp;&nbsp;</span>Evaluate the data from the experiment</a></span></li></ul></li></ul></li><li><span><a href=\"#6.-Problems\" data-toc-modified-id=\"6.-Problems-1.9\"><span class=\"toc-item-num\">1.9&nbsp;&nbsp;</span>6. Problems<a id=\"problems\"></a></a></span></li><li><span><a href=\"#7.-References\" data-toc-modified-id=\"7.-References-1.10\"><span class=\"toc-item-num\">1.10&nbsp;&nbsp;</span>7. References<a id=\"references\"></a></a></span></li></ul></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "tags": [
      "remove_cell"
     ]
@@ -11234,7 +11244,9 @@
     "for sample in list(counts.keys()):\n",
     "\n",
     "    # use sampled bit string x to compute C(x)\n",
-    "    x         = [int(num) for num in list(sample)]\n",
+    "    # note: the samples are in little-endian format,\n",
+    "    # so we need to reverse the list to get qubit values\n",
+    "    x         = [int(num) for num in reversed(list(sample))]\n",
     "    tmp_eng   = cost_function_C(x,G)\n",
     "    \n",
     "    # compute the expectation value and energy distribution\n",
@@ -11282,39 +11294,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r",
-      "Job Status: job is being validated"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Job Status: job is queued (2)     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Job Status: job is queued (1)     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Job Status: job is actively running"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
       "Job Status: job has successfully run\n"
      ]
     }
@@ -13576,7 +13555,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -3,16 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "toc": true
-   },
-   "source": [
-    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
-    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Solving-combinatorial-optimization-problems-using-QAOA\" data-toc-modified-id=\"Solving-combinatorial-optimization-problems-using-QAOA-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Solving combinatorial optimization problems using QAOA</a></span><ul class=\"toc-item\"><li><span><a href=\"#Contents\" data-toc-modified-id=\"Contents-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>Contents</a></span></li><li><span><a href=\"#1.-Introduction-\" data-toc-modified-id=\"1.-Introduction--1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>1. Introduction <a id=\"introduction\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#1.1-Diagonal-Hamiltonians\" data-toc-modified-id=\"1.1-Diagonal-Hamiltonians-1.2.1\"><span class=\"toc-item-num\">1.2.1&nbsp;&nbsp;</span>1.1 Diagonal Hamiltonians</a></span></li></ul></li><li><span><a href=\"#2-Examples:-\" data-toc-modified-id=\"2-Examples:--1.3\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>2 Examples: <a id=\"examples\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#2.1-(weighted)-$MAXCUT$\" data-toc-modified-id=\"2.1-(weighted)-$MAXCUT$-1.3.1\"><span class=\"toc-item-num\">1.3.1&nbsp;&nbsp;</span>2.1 (weighted) $MAXCUT$</a></span></li><li><span><a href=\"#2.2-Constraint-satisfaction-problems-and-$MAX-\\;-3-SAT$.\" data-toc-modified-id=\"2.2-Constraint-satisfaction-problems-and-$MAX-\\;-3-SAT$.-1.3.2\"><span class=\"toc-item-num\">1.3.2&nbsp;&nbsp;</span>2.2 Constraint satisfaction problems and $MAX \\; 3-SAT$.</a></span></li></ul></li><li><span><a href=\"#3.-Approximate-optimization-algorithms-\" data-toc-modified-id=\"3.-Approximate-optimization-algorithms--1.4\"><span class=\"toc-item-num\">1.4&nbsp;&nbsp;</span>3. Approximate optimization algorithms <a id=\"approximateOPT\"></a></a></span></li><li><span><a href=\"#4.-The-QAOA-algorithm-\" data-toc-modified-id=\"4.-The-QAOA-algorithm--1.5\"><span class=\"toc-item-num\">1.5&nbsp;&nbsp;</span>4. The QAOA algorithm <a id=\"QAOA\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#4.1-Overview:\" data-toc-modified-id=\"4.1-Overview:-1.5.1\"><span class=\"toc-item-num\">1.5.1&nbsp;&nbsp;</span>4.1 Overview:</a></span></li><li><span><a href=\"#4.2-The-components-of-the-QAOA-algorithm.\" data-toc-modified-id=\"4.2-The-components-of-the-QAOA-algorithm.-1.5.2\"><span class=\"toc-item-num\">1.5.2&nbsp;&nbsp;</span>4.2 The components of the QAOA algorithm.</a></span></li><li><span><a href=\"#4.2.1-The-QAOA-trial-state-\" data-toc-modified-id=\"4.2.1-The-QAOA-trial-state--1.5.3\"><span class=\"toc-item-num\">1.5.3&nbsp;&nbsp;</span>4.2.1 The QAOA trial state <a id=\"section_421\"></a></a></span></li><li><span><a href=\"#4.2.2-Computing-the-expectation-value-\" data-toc-modified-id=\"4.2.2-Computing-the-expectation-value--1.5.4\"><span class=\"toc-item-num\">1.5.4&nbsp;&nbsp;</span>4.2.2 Computing the expectation value <a id=\"section_422\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#Classical-evaluation\" data-toc-modified-id=\"Classical-evaluation-1.5.4.1\"><span class=\"toc-item-num\">1.5.4.1&nbsp;&nbsp;</span>Classical evaluation</a></span></li><li><span><a href=\"#Evaluation-on-a-quantum-computer\" data-toc-modified-id=\"Evaluation-on-a-quantum-computer-1.5.4.2\"><span class=\"toc-item-num\">1.5.4.2&nbsp;&nbsp;</span>Evaluation on a quantum computer</a></span></li></ul></li><li><span><a href=\"#4.3.3-Obtaining-a-solution-with-a-given-approximation-ratio-with-high-probability\" data-toc-modified-id=\"4.3.3-Obtaining-a-solution-with-a-given-approximation-ratio-with-high-probability-1.5.5\"><span class=\"toc-item-num\">1.5.5&nbsp;&nbsp;</span>4.3.3 Obtaining a solution with a given approximation ratio with high probability</a></span></li></ul></li><li><span><a href=\"#5.-Qiskit-Implementation\" data-toc-modified-id=\"5.-Qiskit-Implementation-1.6\"><span class=\"toc-item-num\">1.6&nbsp;&nbsp;</span>5. Qiskit Implementation<a id=\"implementation\"></a></a></span><ul class=\"toc-item\"><li><span><a href=\"#5.1-Problem-definition\" data-toc-modified-id=\"5.1-Problem-definition-1.6.1\"><span class=\"toc-item-num\">1.6.1&nbsp;&nbsp;</span>5.1 Problem definition</a></span></li><li><span><a href=\"#5.2-Optimal-trial-state-parameters\" data-toc-modified-id=\"5.2-Optimal-trial-state-parameters-1.6.2\"><span class=\"toc-item-num\">1.6.2&nbsp;&nbsp;</span>5.2 Optimal trial state parameters<a id=\"implementation_sec52\"></a></a></span></li><li><span><a href=\"#5.3-Quantum-circuit\" data-toc-modified-id=\"5.3-Quantum-circuit-1.6.3\"><span class=\"toc-item-num\">1.6.3&nbsp;&nbsp;</span>5.3 Quantum circuit<a id=\"implementation_sec53\"></a></a></span></li><li><span><a href=\"#5.4--Cost-function-evaluation\" data-toc-modified-id=\"5.4--Cost-function-evaluation-1.6.4\"><span class=\"toc-item-num\">1.6.4&nbsp;&nbsp;</span>5.4  Cost function evaluation<a id=\"implementation_sec54\"></a></a></span></li></ul></li><li><span><a href=\"#5a.-Running-QAOA-on-a-simulator\" data-toc-modified-id=\"5a.-Running-QAOA-on-a-simulator-1.7\"><span class=\"toc-item-num\">1.7&nbsp;&nbsp;</span>5a. Running QAOA on a simulator<a id=\"implementationsim\"></a></a></span><ul class=\"toc-item\"><li><ul class=\"toc-item\"><li><span><a href=\"#Evaluate-the-date-from-the-simulation\" data-toc-modified-id=\"Evaluate-the-date-from-the-simulation-1.7.0.1\"><span class=\"toc-item-num\">1.7.0.1&nbsp;&nbsp;</span>Evaluate the date from the simulation</a></span></li></ul></li></ul></li><li><span><a href=\"#5b.-Running-QAOA-on-a-real-quantum-device\" data-toc-modified-id=\"5b.-Running-QAOA-on-a-real-quantum-device-1.8\"><span class=\"toc-item-num\">1.8&nbsp;&nbsp;</span>5b. Running QAOA on a real quantum device<a id=\"implementationdev\"></a></a></span><ul class=\"toc-item\"><li><ul class=\"toc-item\"><li><span><a href=\"#Evaluate-the-data-from-the-experiment\" data-toc-modified-id=\"Evaluate-the-data-from-the-experiment-1.8.0.1\"><span class=\"toc-item-num\">1.8.0.1&nbsp;&nbsp;</span>Evaluate the data from the experiment</a></span></li></ul></li></ul></li><li><span><a href=\"#6.-Problems\" data-toc-modified-id=\"6.-Problems-1.9\"><span class=\"toc-item-num\">1.9&nbsp;&nbsp;</span>6. Problems<a id=\"problems\"></a></a></span></li><li><span><a href=\"#7.-References\" data-toc-modified-id=\"7.-References-1.10\"><span class=\"toc-item-num\">1.10&nbsp;&nbsp;</span>7. References<a id=\"references\"></a></a></span></li></ul></li></ul></div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "tags": [
      "remove_cell"
     ]
@@ -13556,19 +13546,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.3"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": true,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)

Fixes #500 
## What Changes Were Made?

Use reversed key of samples dictionary, to account for littlie-endianness of resulting states

## How Was This Tested?

Tested on a graph with following adjacency matrix:
```
[[0. 1. 0. 1.]
 [1. 0. 1. 1.]
 [0. 1. 0. 1.]
 [1. 1. 1. 0.]]
```
