### PR TITLE
Fix Strange Image Sizings

### DIFF
--- a/_sass/page/components/_components.page.scss
+++ b/_sass/page/components/_components.page.scss
@@ -211,9 +211,6 @@ div.text_cell_render > p > a > img {
   margin-right: auto;
 }
 
-.output_png img {
-  width: 100% !important;
-}
 
 .hl-ipython3 pre::before,
 .output_subarea pre::before,


### PR DESCRIPTION
Problematic line of css was forcing images to scale strangely, notably in shor's algorithm and the QIP chapters. I have removed the line.