### PR TITLE
Matplotlib 3.3.0 Update: arg s => text

### DIFF
--- a/content/ch-algorithms/shor.ipynb
+++ b/content/ch-algorithms/shor.ipynb
@@ -1233,8 +1233,8 @@
     "       title=\"Example of Periodic Function in Shor's Algorithm\")\n",
     "try: # plot r on the graph\n",
     "    r = yvals[1:].index(1) +1 \n",
-    "    plt.annotate(s='', xy=(0,1), xytext=(r,1), arrowprops=dict(arrowstyle='<->'))\n",
-    "    plt.annotate(s='$r=%i$' % r, xy=(r/3,1.5))\n",
+    "    plt.annotate(text='', xy=(0,1), xytext=(r,1), arrowprops=dict(arrowstyle='<->'))\n",
+    "    plt.annotate(text='$r=%i$' % r, xy=(r/3,1.5))\n",
     "except:\n",
     "    print('Could not find period, check a < N and have no common factors.')"
    ]


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)

While using Matplotlib 3.3.0:

```
MatplotlibDeprecationWarning: The 's' parameter of annotate() has been renamed 'text' since Matplotlib 3.3; support for the old name will be dropped two minor releases later.
  app.launch_new_instance()
```

This pull request will update the notebook to the most recent Matplotlib standards.

## What Changes Were Made?

I renamed the "s" argument to "text"

## How Was This Tested?

Before update:
![Screen Shot 2020-07-23 at 9 22 01 AM](https://user-images.githubusercontent.com/25377399/88311682-0f451d00-ccc6-11ea-961c-5cd2d2e301bf.png)

After update:
![Screen Shot 2020-07-23 at 9 22 24 AM](https://user-images.githubusercontent.com/25377399/88311700-166c2b00-ccc6-11ea-8ece-34ccf55b6105.png)

## Anything Else We Should Know 
![Screen Shot 2020-07-23 at 9 25 49 AM](https://user-images.githubusercontent.com/25377399/88312034-81b5fd00-ccc6-11ea-897a-9bd9e4be0f38.png)

Pull request will break period finding as the "text" argument throws an exception
``` TypeError: annotate() missing 1 required positional argument: 's'```

I think it's best to let this request wait until matplotlib 3.3.0 is more standard.