### PR TITLE
Equation typo

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -1584,7 +1584,7 @@
     "\n",
     "There is a simple rule for measurement. To find the probability of measuring a state $|\\psi \\rangle$ in the state $|x\\rangle$ we do:\n",
     "\n",
-    "$$p(|x\\rangle) = | \\langle \\x| psi \\rangle|^2$$\n",
+    "$$p(|x\\rangle) = | \\langle x| \\psi \\rangle|^2$$\n",
     "\n",
     "The symbols $\\langle$ and $|$ tell us $\\langle x |$ is a row vector. In quantum mechanics we call the column vectors _kets_ and the row vectors _bras._ Together they make up _bra-ket_ notation. Any ket $|a\\rangle$ has a corresponding bra $\\langle a|$, and we convert between them using the conjugate transpose.\n",
     "\n",


### PR DESCRIPTION
Equation typo made the result show "\x | psi" instead of just the letter "x" and the symbol "psi".

This typo comes from PR #575, which switched "x" and "psi" but left the "\\" in its old place. 