### PR TITLE
Fix: Typo in Pauli Matrices

### DIFF
--- a/content/ch-appendix/linear_algebra.ipynb
+++ b/content/ch-appendix/linear_algebra.ipynb
@@ -8640,7 +8640,7 @@
     "<br>\n",
     "\n",
     "\n",
-    "$$\\sigma_y \\ = \\ \\begin{pmatrix} 0 & i \\\\ -i & 0 \\end{pmatrix}$$\n",
+    "$$\\sigma_y \\ = \\ \\begin{pmatrix} 0 & -i \\\\ i & 0 \\end{pmatrix}$$\n",
     "\n",
     "\n",
     "<br>\n",


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)
Typo in Sigma_Y
![image](https://user-images.githubusercontent.com/32785524/88486948-61e53a00-cf4f-11ea-8089-c1fed2c86c8d.png)

Fixes #your_issue_number_here
Fixed to 

## What Changes Were Made?
![image](https://user-images.githubusercontent.com/32785524/88486968-77f2fa80-cf4f-11ea-8a93-8211637cd609.png)

## How Was This Tested?

Please provide any screenshots if applicable.

## Anything Else We Should Know 
