### PR TITLE
8.1 Change variable, hide code

### DIFF
--- a/content/ch-appendix/linear_algebra.ipynb
+++ b/content/ch-appendix/linear_algebra.ipynb
@@ -14,7 +14,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
@@ -42,7 +46,10 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": [
+     "remove_input"
+    ]
    },
    "outputs": [
     {
@@ -476,7 +483,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_input"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -4559,7 +4570,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_input"
+    ]
+   },
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
This PR incorporates #261, it also adds `remove_input` tags to the code cells so they are not shown on the website. The code is unexplained and has confused some readers.