### PR TITLE
2.3, 1 Corrected the swapping of CNOT gate

### DIFF
--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -311,7 +311,7 @@
     "\n",
     "$$ |{+}{+}\\rangle = \\tfrac{1}{2}(|00\\rangle + |01\\rangle + |10\\rangle + |11\\rangle) $$\n",
     "\n",
-    "Since the CNOT swaps the amplitudes of $|01\\rangle$ and $|11\\rangle$, we see no change:"
+    "Since the CNOT swaps the amplitudes of $|10\\rangle$ and $|11\\rangle$, we see no change:"
    ]
   },
   {


### PR DESCRIPTION

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
The 01 state is changed to 10.
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
The CNOT gate swaps 10 and 11 qubits rather than 01 and 11.
