### PR TITLE
Section 3.2 > Change initialise to initialize for consistency w/ other docs

### DIFF
--- a/content/ch-algorithms/teleportation.ipynb
+++ b/content/ch-algorithms/teleportation.ipynb
@@ -2478,7 +2478,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook, we will initialise Alice's qubit in a random state $\\vert\\psi\\rangle$ (`psi`). This state will be created using an `Initialize` gate on $|q_0\\rangle$. In this chapter we use the function `random_state` to choose `psi` for us, but feel free to set `psi` to any qubit state you want."
+    "In this notebook, we will initialize Alice's qubit in a random state $\\vert\\psi\\rangle$ (`psi`). This state will be created using an `Initialize` gate on $|q_0\\rangle$. In this chapter we use the function `random_state` to choose `psi` for us, but feel free to set `psi` to any qubit state you want."
    ]
   },
   {
@@ -6451,7 +6451,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create our initialisation gate to create $|\\psi\\rangle$ from the state $|0\\rangle$:"
+    "Let's create our initialization gate to create $|\\psi\\rangle$ from the state $|0\\rangle$:"
    ]
   },
   {
@@ -7527,7 +7527,7 @@
     "qc = QuantumCircuit(qr, crz, crx)\n",
     "\n",
     "## STEP 0\n",
-    "# First, let's initialise Alice's q0\n",
+    "# First, let's initialize Alice's q0\n",
     "qc.append(init_gate, [0])\n",
     "qc.barrier()\n",
     "\n",
@@ -7556,7 +7556,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At the time of writing, there is a rendering issue with the `Initialise` gate in the image above, but the circuit operates just fine. We can see below, using our statevector simulator, that the state of $|q_2\\rangle$ is the same as the state $|\\psi\\rangle$ we created above, while the states of $|q_0\\rangle$ and $|q_1\\rangle$ have been collapsed to either $|0\\rangle$ or $|1\\rangle$. The state $|\\psi\\rangle$ has been teleported from qubit 0 to qubit 2."
+    "At the time of writing, there is a rendering issue with the `Initialize` gate in the image above, but the circuit operates just fine. We can see below, using our statevector simulator, that the state of $|q_2\\rangle$ is the same as the state $|\\psi\\rangle$ we created above, while the states of $|q_0\\rangle$ and $|q_1\\rangle$ have been collapsed to either $|0\\rangle$ or $|1\\rangle$. The state $|\\psi\\rangle$ has been teleported from qubit 0 to qubit 2."
    ]
   },
   {
@@ -18949,9 +18949,9 @@
     "\n",
     "On a real quantum computer, we would not be able to sample the statevector, so if we wanted to check our teleportation circuit is working, we need to do things slightly differently. You will remember that we used `Initialize` to turn our $|0\\rangle$ qubit into the state $|\\psi\\rangle$:\n",
     "\n",
-    "$$ |0\\rangle \\xrightarrow{\\text{Initialise}} |\\psi\\rangle $$\n",
+    "$$ |0\\rangle \\xrightarrow{\\text{Initialize}} |\\psi\\rangle $$\n",
     "\n",
-    "Since all quantum gates are reversible, we can find the inverse of Initialise using:"
+    "Since all quantum gates are reversible, we can find the inverse of Initialize using:"
    ]
   },
   {
@@ -18973,9 +18973,9 @@
    "source": [
     "This operation has the property:\n",
     "\n",
-    "$$ |\\psi\\rangle \\xrightarrow{\\text{Inverse Initialise}} |0\\rangle $$\n",
+    "$$ |\\psi\\rangle \\xrightarrow{\\text{Inverse Initialize}} |0\\rangle $$\n",
     "\n",
-    "To prove the qubit $|q_0\\rangle$ has been teleported to $|q_2\\rangle$, if we do this inverse initialisation on $|q_2\\rangle$, we expect to measure $|0\\rangle$ with certainty. We do this in the circuit below:"
+    "To prove the qubit $|q_0\\rangle$ has been teleported to $|q_2\\rangle$, if we do this inverse initialization on $|q_2\\rangle$, we expect to measure $|0\\rangle$ with certainty. We do this in the circuit below:"
    ]
   },
   {
@@ -20221,7 +20221,7 @@
     "qc = QuantumCircuit(qr, crz, crx)\n",
     "\n",
     "## STEP 0\n",
-    "# First, let's initialise Alice's q0\n",
+    "# First, let's initialize Alice's q0\n",
     "qc.append(init_gate, [0])\n",
     "qc.barrier()\n",
     "\n",
@@ -20243,7 +20243,7 @@
     "bob_gates(qc, 2, crz, crx)\n",
     "\n",
     "## STEP 5\n",
-    "# reverse the initialisation process\n",
+    "# reverse the initialization process\n",
     "qc.append(inverse_init_gate, [2])\n",
     "\n",
     "# Display the circuit\n",
@@ -23551,7 +23551,7 @@
    "source": [
     "qc = QuantumCircuit(3,1)\n",
     "\n",
-    "# First, let's initialise Alice's q0\n",
+    "# First, let's initialize Alice's q0\n",
     "qc.append(init_gate, [0])\n",
     "qc.barrier()\n",
     "\n",
@@ -23564,7 +23564,7 @@
     "# Alice sends classical bits to Bob\n",
     "new_bob_gates(qc, 0, 1, 2)\n",
     "\n",
-    "# We undo the initialisation process\n",
+    "# We undo the initialization process\n",
     "qc.append(inverse_init_gate, [2])\n",
     "\n",
     "# See the results, we only care about the state of qubit 2\n",


### PR DESCRIPTION
# Changes made
Changed occurrences of "initialise" and "initialisation" to "initialize" and "initialization" respectively

# Justification
While the spellings were not incorrect, there was inconsistent usage throughout the section of "s" vs "z". Other relevant documentation (https://qiskit.org/documentation/stubs/qiskit.extensions.Initialize.html) uses the "z" spelling so I changed them for consistency. 
