### PR TITLE
2.6 Corrected grammar and replaced word

### DIFF
--- a/content/ch-gates/oracles.ipynb
+++ b/content/ch-gates/oracles.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "The advantage of thinking of the oracle in this abstract way allows us to concentrate on the quantum techniques we use to analyze the function, rather than the function itself. \n",
     "\n",
-    "In order to understand how an oracles work within a quantum algorithm, we need to be specific about how they are defined. One of the  main forms that oracles take is that of *Boolean oracles*. These are described by the following unitary evolution,\n",
+    "In order to understand how an oracle works within a quantum algorithm, we need to be specific about how they are defined. One of the  main forms that oracles take is that of *Boolean oracles*. These are described by the following unitary evolution,\n",
     "\n",
     "$$\n",
     "U_f \\left|x , \\bar 0 \\right\\rangle = \\left|x, f(x)\\right\\rangle.\n",
@@ -85,7 +85,7 @@
    "source": [
     "## 3. Taking Out the Garbage <a id='garbage'></a>\n",
     "\n",
-    "The functions evaluated by an oracle are typically those that can be evaluated efficiently on a classical computer. However, the need to implement it as a unitary in one of the forms shown above means that it must instead be implemented using quantum gates. However, this is not quite as simple as just taking the Boolean gates that can implement the classical algorithm, and replacing them with their classical counterparts.\n",
+    "The functions evaluated by an oracle are typically those that can be evaluated efficiently on a classical computer. However, the need to implement it as a unitary in one of the forms shown above means that it must instead be implemented using quantum gates. However, this is not quite as simple as just taking the Boolean gates that can implement the classical algorithm, and replacing them with their quantum counterparts.\n",
     "\n",
     "One issue that we must take care of is that of reversibility. A unitary of the form $U = \\sum_x \\left| f(x) \\right\\rangle \\left\\langle x \\right|$ is only possible if every unique input $x$ results in a unique output $f(x)$, which is not true in general. However, we can force it to be true by simply including a copy of the input in the output. It is this that leads us to the form for Boolean oracles as we saw earlier\n",
     "$$\n",
@@ -2839,7 +2839,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Corrected grammar: changed 'how an oracles work' to 'how an oracle works'.
Replaced word: Replaced 'classical' with 'quantum'

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
Paragraph 3 discusses the reason to implement the classical algorithm in a reversible fashion due to the fact that all quantum operations are to be unitary. However, this does not simply mean replacing the boolean gates with their "quantum" counterparts. 

The quoted text had "classical" instead which is incorrect.