### PR TITLE
6.4 Fixes issue #699

### DIFF
--- a/content/ch-quantum-hardware/cQED-JC-SW.ipynb
+++ b/content/ch-quantum-hardware/cQED-JC-SW.ipynb
@@ -43,7 +43,7 @@
     "$$\n",
     "that generate rotations the respective axes around the Bloch sphere. In that case, the simplest model to describe this interaction is the Jaynes-Cummings Hamiltonian in the rotating wave approximation,\n",
     "$$\n",
-    "H_{\\rm JC}^{\\rm (RWA)}/\\hbar = \\omega_r a^\\dagger a - \\frac{1}{2} \\omega_q \\sigma_z + g(a^\\dagger \\sigma^- + a \\sigma^+).\n",
+    "H_{\\rm JC}^{\\rm (RWA)}/\\hbar = \\omega_r a^\\dagger a + \\frac{1}{2} \\omega_q \\sigma_z + g(a^\\dagger \\sigma^- + a \\sigma^+).\n",
     "$$\n",
     "where $\\omega_r$ and $\\omega_r$ are the frequencies of the resonator and \"qubit\", respectively, $a$ ($a^\\dagger$) is the resonator photon annihilation (creation) operator, and $g$ is the electric dipole coupling (half the vacuum Rabi splitting). Note that we are now omitting the hats from the operators. Here, the first term corresponds to the number of photons in the resonator, the second term corresponds to the state of the qubit, and the third is the electric dipole interaction, where $\\sigma^\\pm = (1/2)(\\sigma^x \\mp i\\sigma^y)$ is the qubit raising/lowering operator. (Note that the signs are inverted from those of *spin* raising/lowering operators, as discussed in the previous chapter).\n",
     "\n",
@@ -627,7 +627,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
The definition for the Jaynes-Cummings Hamiltonian had a typo where instead of a "+", a "-" was present. Changed "+" to "-".

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
As pointed out in issue #699 , and verified through http://aliramadhan.me/files/jaynes-cummings-model.pdf
