### PR TITLE
Added other Bell's state in the entanglement section

### DIFF
--- a/content/ch-gates/multiple-qubits-entangled-states.ipynb
+++ b/content/ch-gates/multiple-qubits-entangled-states.ipynb
@@ -1724,7 +1724,7 @@
     "We saw in the previous section we could create the state:\n",
     "\n",
     "$$\n",
-    "\\tfrac{1}{\\sqrt{2}}(|00\\rangle + |11\\rangle)\n",
+    "|\\Phi^-\\rangle = \\tfrac{1}{\\sqrt{2}}(|00\\rangle + |11\\rangle)\n",
     "$$ \n",
     "\n",
     "This is known as a _Bell_ state. We can see that this state has 50% probability of being measured in the state $|00\\rangle$, and 50% chance of being measured in the state $|11\\rangle$. Most interestingly, it has a **0%** chance of being measured in the states $|01\\rangle$ or $|10\\rangle$. We can see this in Qiskit:"
@@ -2378,6 +2378,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The other three Bell's states are,\n",
+    "$$\n",
+    "|\\Phi^-\\rangle = \\frac{1}{\\sqrt{2}} (|00\\rangle - |11\\rangle)$$\n",
+    "$$|\\Psi^+\\rangle = \\frac{1}{\\sqrt{2}} (|01\\rangle + |10\\rangle)$$\n",
+    "$$|\\Psi^-\\rangle = \\frac{1}{\\sqrt{2}} (|01\\rangle - |10\\rangle)$$\n",
+    "\n",
+    "They are of fundamental importance to quantum mechanics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This combined state cannot be written as two separate qubit states, which has interesting implications. Although our qubits are in superposition, measuring one will tell us the state of the other and collapse its superposition. For example, if we measured the top qubit and got the state $|1\\rangle$, the collective state of our qubits changes like so:\n",
     "\n",
     "$$\n",
@@ -2453,7 +2466,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
Fixes #708 
# Changes made
<!--- Please state what you did --->
Added other Bell's state in the entanglement section

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
The textbook lacked the introduction of other Bell's state.