### PR TITLE
Added an analogy to chapter 3.2

### DIFF
--- a/content/ch-algorithms/teleportation.ipynb
+++ b/content/ch-algorithms/teleportation.ipynb
@@ -20,16 +20,17 @@
     "## Contents\n",
     "\n",
     "1. [Overview](#overview)    \n",
-    "2. [The Quantum Teleportation Protocol](#how)       \n",
-    "3. [Simulating the Teleportation Protocol](#simulating)   \n",
-    "    3.1 [How will we Test this Result on a Real Quantum Computer?](#testing)   \n",
-    "    3.2 [Using the Statevector Simulator](#simulating-sv)     \n",
-    "    3.3 [Using the QASM Simulator](#simulating-qs)  \n",
-    "4. [Understanding Quantum Teleportation](#understanding-qt)\n",
-    "5. [Teleportation on a Real Quantum Computer](#real_qc)    \n",
-    "    5.1 [IBM hardware and Deferred Measurement](#deferred-measurement)    \n",
-    "    5.2 [Executing](#executing)    \n",
-    "6. [References](#references)\n",
+    "2. [The Quantum Teleportation Protocol](#how) \n",
+    "3. [Jacklyn sends Vivian Roses: An Analogy](#analogy)\n",
+    "4. [Simulating the Teleportation Protocol](#simulating)   \n",
+    "    4.1 [How will we Test this Result on a Real Quantum Computer?](#testing)   \n",
+    "    4.2 [Using the Statevector Simulator](#simulating-sv)     \n",
+    "    4.3 [Using the QASM Simulator](#simulating-qs)  \n",
+    "5. [Understanding Quantum Teleportation](#understanding-qt)\n",
+    "6. [Teleportation on a Real Quantum Computer](#real_qc)    \n",
+    "    6.1 [IBM hardware and Deferred Measurement](#deferred-measurement)    \n",
+    "    6.2 [Executing](#executing)    \n",
+    "7. [References](#references)\n",
     "\n"
    ]
   },
@@ -2454,14 +2455,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Simulating the Teleportation Protocol <a id='simulating'></a>"
+    "## 3. Jacklyn sends Vivian Roses: An Analogy <a id='analogy'></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.1 How Will We Test the Protocol on a Quantum Computer? <a id='testing'></a>"
+    "Now that we know the quantum teleportation protocol, I want to take a step back and make the protocol more relatable with an analogy.\n",
+    "\n",
+    "Jacklyn, the first qubit, wants to send roses to Vivian. Those roses are the information stored in the first qubit. In order to send the roses, she gets help from FlowerDelivery, a delivery company, to deliver the roses to Vivian. The company provides the delivery truck and Vivian's information, and together those pieces of information help determine the directions to Vivian's house. The entangled qubit channel is this route, while the entangled qubits are the delivery truck and Vivian.\n",
+    "\n",
+    "Jacklyn behaves the same way that Alice's qubit does in the Quantum Teleportation protocol. Just like how Alice's qubit loses its state once it sends it to the second qubit, Jacklyn loses her roses once she gives the roses to the delivery truck. \n",
+    "\n",
+    "The delivery truck then takes the roses and starts its journey to Vivian's house.\n",
+    "\n",
+    "A lot could happen to the delivery truck while it is transporting the roses. Ideally we would like the roses to be delivered swiftly and in their original condition, but life is unpredictable. The truck could break down midway, leaving the roses too long without proper nutrients; someone could rob the truck of the roses; etc. The more complicated the information, the more possibilities exist. Only when the roses arrive does Vivian know if there are any problems with the delivery. This unpredictability correlates to that of measuring the first two qubits in the Quantum Teleportation protocol. Before measuring the first qubits we don't know if each qubit will collapse to the state |0> or |1>. \n",
+    "\n",
+    "Finally, the truck arrives at Vivian's house. Vivian gets the roses and they are in perfect condition. Great, everything worked out! This outcome is equivalent to Alice's qubit and the second qubit together returning the state |00> after measurement. But suppose something else happens to the roses: they come wilted because the truck broke down temporarily, or worse they don't arrive because the roses were stolen, etc. Since the goal was to give Jacklyn's roses to Vivian in their original condition, Vivian needs to take action to get healthy roses. She will have to buy healthy roses or flower food and be compensated by the FlowerDelivery company, etc. This adjustment depending on the condition of the flowers is equivalent to applying the rotations needed for Bob's qubit to receive the delivered state.\n",
+    "\n",
+    "In this analogy it may seem that the roses Vivian receives in a worse case scenario aren't the same as what Jacklyn sends. What is more important than receiving those specific flowers is that Vivian receives the same kind of healthy roses.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Simulating the Teleportation Protocol <a id='simulating'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 How Will We Test the Protocol on a Quantum Computer? <a id='testing'></a>"
    ]
   },
   {
@@ -6481,7 +6509,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2 Using the Statevector Simulator <a id='simulating-sv'></a>\n",
+    "### 4.2 Using the Statevector Simulator <a id='simulating-sv'></a>\n",
     "\n",
     "We can use the statevector simulator to verify our qubit has been teleported."
    ]
@@ -18990,7 +19018,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3 Using the QASM Simulator <a id='simulating-qs'></a>\n",
+    "### 4.3 Using the QASM Simulator <a id='simulating-qs'></a>\n",
     "\n",
     "Quantum teleportation is designed to send qubits between two parties. We do not have the hardware to demonstrate this, but we can demonstrate that the gates perform the correct transformations on a single quantum chip. Here we use the QASM simulator to simulate how we might test our protocol.\n",
     "\n",
@@ -22446,7 +22474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Understanding Quantum Teleportation <a id=\"understanding-qt\">"
+    "## 5. Understanding Quantum Teleportation <a id=\"understanding-qt\">"
    ]
   },
   {
@@ -22536,14 +22564,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Teleportation on a Real Quantum Computer <a id='real_qc'></a>"
+    "## 6. Teleportation on a Real Quantum Computer <a id='real_qc'></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5.1 IBM hardware and Deferred Measurement <a id='deferred-measurement'></a>\n",
+    "### 6.1 IBM hardware and Deferred Measurement <a id='deferred-measurement'></a>\n",
     "\n",
     "The IBM quantum computers currently do not support instructions after measurements, meaning we cannot run the quantum teleportation in its current form on real hardware. Fortunately, this does not limit our ability to perform any computations due to the _deferred measurement principle_ discussed in chapter 4.4 of [1]. The principle states that any measurement can be postponed until the end of the circuit, i.e. we can move all the measurements to the end, and we should see the same results.\n",
     "\n",
@@ -23689,7 +23717,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5.2 Executing <a id='executing'></a> "
+    "### 6.2 Executing <a id='executing'></a> "
    ]
   },
   {
@@ -24479,7 +24507,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. References <a id='references'></a>\n",
+    "## 7. References <a id='references'></a>\n",
     "[1] M. Nielsen and I. Chuang, Quantum Computation and Quantum Information, Cambridge Series on Information and the Natural Sciences (Cambridge University Press, Cambridge, 2000).\n",
     "\n",
     "[2] Eleanor Rieffel and Wolfgang Polak, Quantum Computing: a Gentle Introduction (The MIT Press Cambridge England, Massachusetts, 2011)."


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
I added an analogy about the quantum teleportation protocol being similar to a friend sending roses to another friend, and added a comparison to the protocol at each step of the analogy.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
I initially had a hard time understanding the protocol the way it is, and I thought other people might feel the same way. That is why I added this analogy as a way to help others understand the quantum teleportation protocol. I am very open to all criticism, such as whether this analogy really fits this chapter, there is a better place to put it, the wording could be changed, images should be added, there should be more edits in general, etc. 
