### PR TITLE
2.3 Fix typo (rightmost -> leftmost)

### DIFF
--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -41364,7 +41364,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see the rightmost qubit has been rotated by $\\pi/4$ around the Z-axis of the Bloch sphere as expected. After exploring this behaviour, it may become clear why Qiskit draws the controlled-Z rotation gates in this symmetrical fashion (two controls instead of a control and a target). There is no clear control or target qubit for all cases.\n",
+    "We can see the leftmost qubit has been rotated by $\\pi/4$ around the Z-axis of the Bloch sphere as expected. After exploring this behaviour, it may become clear why Qiskit draws the controlled-Z rotation gates in this symmetrical fashion (two controls instead of a control and a target). There is no clear control or target qubit for all cases.\n",
     "\n",
     "<img src=\"images/pkb_z_equiv.svg\">\n",
     "\n",


### PR DESCRIPTION
# Changes made
Replace "rightmost" with "leftmost"

# Justification
The text says that the rightmost qubit is rotated, but in the picture
above, it is clear that the leftmost qubit is the one that is rotated.