### PR TITLE
Ch: Appendix Linear algebra; Added missing coefficients to ket vector expansion

### DIFF
--- a/content/ch-appendix/linear_algebra.ipynb
+++ b/content/ch-appendix/linear_algebra.ipynb
@@ -4503,7 +4503,7 @@
     "<br>\n",
     "\n",
     "\n",
-    "$$|v_a\\rangle \\ - \\ \\displaystyle\\sum_{s} b_s |v_s\\rangle \\ = \\ |v_a\\rangle \\ - \\ (|v_{s_1}\\rangle \\ + \\ ... \\ + \\ |v_{s_r}\\rangle) \\ = \\ 0$$\n",
+    "$$|v_a\\rangle \\ - \\ \\displaystyle\\sum_{s} b_s |v_s\\rangle \\ = \\ |v_a\\rangle \\ - \\ (b_1|v_{s_1}\\rangle \\ + \\ ... \\ + \\ b_r|v_{s_r}\\rangle) \\ = \\ 0$$\n",
     "\n",
     "\n",
     "<br>\n",
@@ -4512,7 +4512,7 @@
     "\n",
     "<br>\n",
     "\n",
-    "$$|v_a\\rangle \\ - \\ (|v_{s_1}\\rangle \\ + \\ ... \\ + \\ |v_{s_r}\\rangle) \\ + \\ (0)(|v_{q_1}\\rangle \\ + \\ ... \\ + \\ |v_{q_t}\\rangle) \\ = \\ 0$$\n",
+    "$$|v_a\\rangle \\ - \\ (b_1|v_{s_1}\\rangle \\ + \\ ... \\ + \\ b_r|v_{s_r}\\rangle) \\ + \\ (0)(|v_{q_1}\\rangle \\ + \\ ... \\ + \\ |v_{q_t}\\rangle) \\ = \\ 0$$\n",
     "\n",
     "<br>\n",
     "\n",
@@ -8771,7 +8771,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Changed: |v_s1> + .... + |v_sr> to b_1 |v_s1> + ... + b_r |v_sr>

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
The missing coefficients were a source of confusion and adding these coefficients makes the equation much clearer.
