### PR TITLE
pin nbconvert version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+nbconvert==5.6.1
 jupyter-book==0.6.5
 beautifulsoup4
 


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
pin the `nbconvert` version to 5.6.1

# Justification
`nbconvert` 6.0 currently [breaks the build](https://travis-ci.com/github/qiskit-community/qiskit-textbook/builds/183710951). this PR pins it to the previous version (i.e., 5.6.1) which resolves build failures until 6.0 can be properly reviewed and appropriate updates made to support it.

resolves #743 


