### PR TITLE
Fix author separator in .bib file

### DIFF
--- a/content/qiskit-textbook.bib
+++ b/content/qiskit-textbook.bib
@@ -1,6 +1,6 @@
-@misc{ Qiskit-Textbook,
-       author = {Abraham Asfaw, Luciano Bello, Yael Ben-Haim, Sergey Bravyi, Nicholas Bronn, Lauren Capelluto, Almudena Carrera Vazquez, Jack Ceroni,  Richard Chen, Albert Frisch, Jay Gambetta, Shelly Garion, Leron Gil, Salvador De La Puente Gonzalez, Francis Harkins, Takashi Imamichi, David McKay, Antonio Mezzacapo, Zlatko Minev, Ramis Movassagh, Giacomo Nannicni, Paul Nation,  Anna Phan, Marco Pistoia, Arthur Rattew, Joachim Schaefer, Javad Shabani, John Smolin, Kristan Temme, Madeleine Tod, Stephen Wood, James Wootton.},
-       title = {Learn Quantum Computation Using Qiskit},
-       year = {2020},
-       url = {http://community.qiskit.org/textbook},
+@electronic{Qiskit-Textbook,
+	author = {Abraham Asfaw and Luciano Bello and Yael Ben-Haim and Sergey Bravyi and Nicholas Bronn and Lauren Capelluto and Almudena Carrera Vazquez and Jack Ceroni and Richard Chen and Albert Frisch and Jay Gambetta and Shelly Garion and Leron Gil and Salvador De La Puente Gonzalez and Francis Harkins and Takashi Imamichi and David McKay and Antonio Mezzacapo and Zlatko Minev and Ramis Movassagh and Giacomo Nannicni and Paul Nation and Anna Phan and Marco Pistoia and Arthur Rattew and Joachim Schaefer and Javad Shabani and John Smolin and Kristan Temme and Madeleine Tod and Stephen Wood and James Wootton.},
+	title = {Learn Quantum Computation Using Qiskit},
+	year = {2020},
+	url = {http://community.qiskit.org/textbook},
 }


### PR DESCRIPTION
# Changes made
Replace commas in `.bib` file with `and` keyword

# Justification
When using the natbib package, using a comma between authors makes all but the last names take their initials. [The correct way in natbib to separate authors is with the word "and".](https://tex.stackexchange.com/questions/36396/how-to-properly-write-multiple-authors-in-bibtex-file)
![image](https://user-images.githubusercontent.com/8503756/92983594-bcdcdd00-f47a-11ea-8013-d17c33893b98.png)
Forgive me if this file is not meant for natbib.


