### PR TITLE
3.1 Fixed broken link to "The Atoms of Computation".

### DIFF
--- a/content/ch-gates/multiple-qubits-entangled-states.ipynb
+++ b/content/ch-gates/multiple-qubits-entangled-states.ipynb
@@ -990,7 +990,7 @@
     "\n",
     "### 3.1 The CNOT-Gate <a id=\"cnot\"></a>\n",
     "\n",
-    "You have come across this gate before in _[The Atoms of Computation](../ch-states/atoms-computation.ipynb)._ This gate is a conditional gate that performs an X-gate on the second qubit (target), if the state of the first qubit (control) is $|1\\rangle$. The gate is drawn on a circuit like this, with `q0` as the control and `q1` as the target:"
+    "You have come across this gate before in _[The Atoms of Computation](../ch-states/atoms-computation.html)._ This gate is a conditional gate that performs an X-gate on the second qubit (target), if the state of the first qubit (control) is $|1\\rangle$. The gate is drawn on a circuit like this, with `q0` as the control and `q1` as the target:"
    ]
   },
   {


### PR DESCRIPTION
#Changes made
Fixed the follwing link
https://qiskit.org/textbook/ch-states/atoms-computation.ipynb --> https://qiskit.org/textbook/ch-states/atoms-computation.html

# Justification
The current link is broken. The change is necessary for the link to work.
