### PR TITLE
Support closing sidebar in mobile

### DIFF
--- a/_sass/components/_components.book__layout.scss
+++ b/_sass/components/_components.book__layout.scss
@@ -123,6 +123,10 @@ div.qiskit__navbar {
     /* [4] */
     transform: translate($left-sidebar-width, 0);
 
+    @include mq($until: $left-sidebar-width + $spacing-unit-small * 5) {
+      transform: translateX(100vw) translateX(-60px);
+    }
+
     @include mq($from: tablet) {
       /* [5] */
       width: calc(100% - #{$left-sidebar-width});

--- a/_sass/components/_components.book__layout.scss
+++ b/_sass/components/_components.book__layout.scss
@@ -80,6 +80,10 @@ div.qiskit__navbar {
   left: 0;
   background-color: $color-dark-gray;
   direction: rtl;
+
+  @include mq($until: $left-sidebar-width + $spacing-unit-small * 5) {
+    width: calc(100vw - #{$spacing-unit-small * 5});
+  }
 }
 
 .c-sidebar__chapters {

--- a/_sass/components/_components.book__layout.scss
+++ b/_sass/components/_components.book__layout.scss
@@ -128,7 +128,7 @@ div.qiskit__navbar {
     transform: translate($left-sidebar-width, 0);
 
     @include mq($until: $left-sidebar-width + $spacing-unit-small * 5) {
-      transform: translateX(100vw) translateX(-60px);
+      transform: translateX(100vw) translateX(-$spacing-unit-small * 5);
     }
 
     @include mq($from: tablet) {


### PR DESCRIPTION
allow navigation sidebar to be closed when opening in mobile

fixes #689 


# Changes made
CSS has been updated to account for opening the sidebar on smaller screens. more specifically, an additional media query was added to account for screen widths smaller than the default sidebar width.

# Justification
this change was made to allow users to more easily be able to navigate the textbook on a smaller screen (e.g., mobile device)
