### PR TITLE
5.3, 4 Update broken link

### DIFF
--- a/content/ch-quantum-hardware/randomized-benchmarking.ipynb
+++ b/content/ch-quantum-hardware/randomized-benchmarking.ipynb
@@ -2863,7 +2863,7 @@
     "For example, it is common to perform 2Q RB on the subset of two-qubits defining a CNOT gate while the other qubits are quiescent. As explained in [4], this RB data will not necessarily decay exponentially because the other qubit subspaces are not twirled. Subsets are more rigorously characterized by simultaneous RB, which also measures some level of crosstalk error since all qubits are active.\n",
     "\n",
     "An example of simultaneous RB (1Q RB and 2Q RB) can be found in: \n",
-    "https://github.com/Qiskit/qiskit-tutorials/blob/master/qiskit/ignis/randomized_benchmarking.ipynb"
+    "https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/noise/4_randomized_benchmarking.ipynb"
    ]
   },
   {


### PR DESCRIPTION
Fix broken link to simultaneous RB notebook

Fixes #747 


# Changes made
Updated the link to the example of simultaneous RB (1Q RB and 2Q RB) notebook

# Justification
The current link is broken and does not properly redirect readers to the simultaneous RB notebook
