### PR TITLE
5.2 Fixed issue 732 by changing the state

### DIFF
--- a/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
+++ b/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
@@ -210,17 +210,17 @@
     "    0.0001&0.0103&0.0090&0.9805\n",
     "\\end{pmatrix}\n",
     "\\begin{pmatrix}\n",
+    "    5000 \\\\\n",
     "    0 \\\\\n",
-    "    5000 \\\\\n",
-    "    5000 \\\\\n",
-    "    0\n",
+    "    0 \\\\\n",
+    "    5000\n",
     "\\end{pmatrix}\n",
     "=\n",
     "\\begin{pmatrix}\n",
+    "    4904.5 \\\\\n",
     "    101 \\\\\n",
-    "    4895.5 \\\\\n",
-    "    4908 \\\\\n",
-    "    96.5\n",
+    "    91.5 \\\\\n",
+    "    4903\n",
     "\\end{pmatrix}.\n",
     "$$\n",
     "\n",
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -237,10 +237,10 @@
      "output_type": "stream",
      "text": [
       "C_noisy =\n",
-      " [[ 101. ]\n",
-      " [4894.5]\n",
-      " [4908. ]\n",
-      " [  96.5]]\n"
+      " [[4904.5]\n",
+      " [ 101. ]\n",
+      " [  91.5]\n",
+      " [4903. ]]\n"
      ]
     }
    ],
@@ -252,10 +252,10 @@
     "    [0.0096,0.0002,0.9814,0.0087],\n",
     "    [0.0001,0.0103,0.0090,0.9805]]\n",
     "\n",
-    "Cideal = [[0],\n",
-    "          [5000],\n",
-    "          [5000],\n",
-    "          [0]]\n",
+    "Cideal = [[5000],\n",
+    "          [0],\n",
+    "          [0],\n",
+    "          [5000]]\n",
     "\n",
     "Cnoisy = np.dot( M, Cideal)\n",
     "print('C_noisy =\\n',Cnoisy)"
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -323,10 +323,10 @@
      "output_type": "stream",
      "text": [
       "C_mitigated =\n",
-      " [[-2.69429661e-15]\n",
-      " [ 5.00000000e+03]\n",
-      " [ 5.00000000e+03]\n",
-      " [-1.44328993e-15]]\n"
+      " [[5.00000000e+03]\n",
+      " [0.00000000e+00]\n",
+      " [1.42108547e-14]\n",
+      " [5.00000000e+03]]\n"
      ]
     }
    ],
@@ -343,10 +343,10 @@
     "$$\n",
     "C_{mitigated} = \n",
     "\\begin{pmatrix}\n",
+    "    5000 \\\\\n",
     "    0 \\\\\n",
-    "    5000 \\\\\n",
-    "    5000 \\\\\n",
-    "    0\n",
+    "    0 \\\\\n",
+    "    5000\n",
     "\\end{pmatrix}\n",
     "$$\n",
     "\n",
@@ -435,14 +435,7 @@
       "c0_0: ═════════╩══╬═\n",
       "                  ║ \n",
       "c0_1: ════════════╩═\n",
-      "                    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "                    \n",
       "\n",
       "Circuit mcalcal_11\n",
       "      ┌───┐ ░ ┌─┐   \n",
@@ -1750,7 +1743,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.4"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
---

# Changes made
<!--- Please state what you did --->
Fixed issue #732 by changing the matrix of the bell state mentioned in the notebook

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The state mentioned was (|00>+|11>)/sqrt(2) but the code and matrix were for (|10>+|01>)/sqrt(2)
