### PR TITLE
3.7 Fixed Issue756 by updating the QFT Notebook

### DIFF
--- a/content/ch-algorithms/quantum-fourier-transform.ipynb
+++ b/content/ch-algorithms/quantum-fourier-transform.ipynb
@@ -24,7 +24,7 @@
     "3. [Example 1: 1-qubit QFT](#example1)\n",
     "4. [The Quantum Fourier transform](#qfteqn)\n",
     "5. [The Circuit that Implements the QFT](#circuit)\n",
-    "6. [Example 2: 3-qubit QFT](#example1)\n",
+    "6. [Example 2: 3-qubit QFT](#example2)\n",
     "7. [Some Notes About the Form of the QFT Circuit](#formnote)\n",
     "8. [Qiskit Implementation](#implementation)     \n",
     "    8.1 [Example on 3 Qubits](#threeqft)    \n",
@@ -346,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Example 2: 1-qubit QFT <a id='example2'></a>\n",
+    "## 6. Example 2: 3-qubit QFT <a id='example2'></a>\n",
     "\n",
     "The steps to creating the circuit for $\\vert y_3y_2y_1\\rangle = QFT_8\\vert x_3x_2x_1\\rangle$ would be:\n",
     "\n",
@@ -42372,7 +42372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Fixes #756 
Updated the link to section 6 and changed the heading of section6
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The link referred to a different section.
The heading was for 1-qubit while the content was for 3-qubits
