### PR TITLE
fixed typo in chapter 1.3

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "In quantum computers, our basic variable is the _qubit:_ a quantum variant of the bit. These have exactly the same restrictions as normal bits do: they can store only a single binary piece of information, and can only ever give us an output of `0` or `1`. However, they can also be manipulated in ways that can only be described by quantum mechanics. This gives us new gates to play with, allowing us to find new ways to design algorithms.\n",
     "\n",
-    "To fully understand these new gates, we first need understand how to write down qubit states. For this we will use the mathematics of vectors, matrices and complex numbers. Though we will introduce these concepts as we go, it would be best if you are comfortable with them already. If you need a more in-depth explanation or refresher, you can find a guide [here](../ch-prerequisites/linear_algebra.html).\n",
+    "To fully understand these new gates, we first need to understand how to write down qubit states. For this we will use the mathematics of vectors, matrices, and complex numbers. Though we will introduce these concepts as we go, it would be best if you are comfortable with them already. If you need a more in-depth explanation or a refresher, you can find the guide [here](../ch-prerequisites/linear_algebra.html).\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
1.3 fixed typos in the paragraph right above 'contents'

# Changes made
added 'the', 'to', and a comma in the paragraph right above 'contents' 

# Justification
 for readability 
