### PR TITLE
Update atoms-computation.ipynb

### DIFF
--- a/content/ch-states/atoms-computation.ipynb
+++ b/content/ch-states/atoms-computation.ipynb
@@ -5383,11 +5383,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are now halfway to a fully working half adder. We just have the other bit of the output left to do: the one that will live on qubit 4.\n",
+    "We are now halfway to a fully working half adder. We just have the other bit of the output left to do: the one that will live on qubit 3.\n",
     "\n",
     "If you look again at the four possible sums, you’ll notice that there is only one case for which this is ```1``` instead of ```0```: ```1+1```=```10```. It happens only when both the bits we are adding are ```1```.\n",
     "\n",
-    "To calculate this part of the output, we could just get our computer to look at whether both of the inputs are ```1```. If they are — and only if they are — we need to do a NOT gate on qubit 4. That will flip it to the required value of ```1``` for this case only, giving us the output we need.\n",
+    "To calculate this part of the output, we could just get our computer to look at whether both of the inputs are ```1```. If they are — and only if they are — we need to do a NOT gate on qubit 3. That will flip it to the required value of ```1``` for this case only, giving us the output we need.\n",
     "\n",
     "For this, we need a new gate: like a CNOT but controlled on two qubits instead of just one. This will perform a NOT on the target qubit only when both controls are in state ```1```. This new gate is called the *Toffoli*. For those of you who are familiar with Boolean logic gates, it is basically an AND gate.\n",
     "\n",


### PR DESCRIPTION
In the half adder section. We have 4 qubits and we are counting them from 0 to 3, therefore we must use names as qubit 0, 1, 2, 3 only. However in some places of half adder "qubit 4" is used which is a bit confusing for the readers. I have updated it as "qubit 3" which is the right way to write it.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
