### PR TITLE
3.9 Replace tabulate with pandas

### DIFF
--- a/content/ch-algorithms/shor.ipynb
+++ b/content/ch-algorithms/shor.ipynb
@@ -44,7 +44,7 @@
     "from qiskit.visualization import plot_histogram\n",
     "from math import gcd\n",
     "from numpy.random import randint\n",
-    "from tabulate import tabulate\n",
+    "import pandas as pd\n",
     "from fractions import Fraction\n",
     "print(\"Imports Successful\")"
    ]
@@ -3763,12 +3763,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Register Output                    Phase\n",
-      "------------------------  --------------\n",
-      "00000000(bin) = 0(dec)      0/256 = 0.00\n",
-      "10000000(bin) = 128(dec)  128/256 = 0.50\n",
-      "01000000(bin) = 64(dec)    64/256 = 0.25\n",
-      "11000000(bin) = 192(dec)  192/256 = 0.75\n"
+      "            Register Output           Phase\n",
+      "0    00000000(bin) = 0(dec)    0/256 = 0.00\n",
+      "1   01000000(bin) = 64(dec)   64/256 = 0.25\n",
+      "2  10000000(bin) = 128(dec)  128/256 = 0.50\n",
+      "3  11000000(bin) = 192(dec)  192/256 = 0.75\n"
      ]
     }
    ],
@@ -3781,10 +3780,10 @@
     "    # Add these values to the rows in our table:\n",
     "    rows.append([\"%s(bin) = %i(dec)\" % (output, decimal), \n",
     "                 \"%i/%i = %.2f\" % (decimal, 2**n_count, phase)])\n",
-    "# Can use tabulate to print the rows this as a nice ASCII table:\n",
-    "print(tabulate(rows, \n",
-    "               headers=[\"Register Output\", \"Phase\"], \n",
-    "               colalign=(\"left\",\"right\")))"
+    "# Print the rows in a table\n",
+    "headers=[\"Register Output\", \"Phase\"]\n",
+    "df = pd.DataFrame(rows, columns=headers)\n",
+    "print(df)"
    ]
   },
   {
@@ -3879,12 +3878,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Phase    Fraction    Guess for r\n",
-      "-------  ----------  -------------\n",
-      "      0         0/1              1\n",
-      "    0.5         1/2              2\n",
-      "   0.25         1/4              4\n",
-      "   0.75         3/4              4\n"
+      "   Phase Fraction  Guess for r\n",
+      "0   0.00      0/1            1\n",
+      "1   0.25      1/4            4\n",
+      "2   0.50      1/2            2\n",
+      "3   0.75      3/4            4\n"
      ]
     }
    ],
@@ -3893,10 +3891,10 @@
     "for phase in measured_phases:\n",
     "    frac = Fraction(phase).limit_denominator(15)\n",
     "    rows.append([phase, \"%i/%i\" % (frac.numerator, frac.denominator), frac.denominator])\n",
-    "# Print as nice ASCII table\n",
-    "print(tabulate(rows, \n",
-    "               headers=[\"Phase\", \"Fraction\", \"Guess for r\"], \n",
-    "               colalign=('right','right','right')))"
+    "# Print as a table\n",
+    "headers=[\"Phase\", \"Fraction\", \"Guess for r\"]\n",
+    "df = pd.DataFrame(rows, columns=headers)\n",
+    "print(df)"
    ]
   },
   {


### PR DESCRIPTION
Update the Shor's Algorithm's notebook to use `pandas `instead of `tabulate`.

Fixes #733 


# Changes made

Updated the code to use `pandas` instead of `tabulate` to display data in a table

# Justification

`tabulate` is not available/pre-installed in the IBM Quantum Experience. therefore the running the notebook fails with `ModuleNotFound` errors.
