### PR TITLE
5.2 Fixed #731 and corrected code semantics

### DIFF
--- a/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
+++ b/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit import *"
+    "from qiskit import QuantumCircuit, QuantumRegister, Aer, execute"
    ]
   },
   {
@@ -102,7 +102,7 @@
     "        qc.x(0)  \n",
     "    qc.measure(qc.qregs[0],qc.cregs[0])\n",
     "    print(state+' becomes',\n",
-    "          execute(qc,Aer.get_backend('qasm_simulator'),noise_model=noise_model,shots=10000).result().get_counts())"
+    "          execute(qc, Aer.get_backend('qasm_simulator'),noise_model=noise_model,shots=10000).result().get_counts())"
    ]
   },
   {
@@ -144,7 +144,7 @@
     "qc.h(0)\n",
     "qc.cx(0,1)  \n",
     "qc.measure(qc.qregs[0],qc.cregs[0])\n",
-    "print(execute(qc,Aer.get_backend('qasm_simulator'),noise_model=noise_model,shots=10000).result().get_counts())"
+    "print(execute(qc, Aer.get_backend('qasm_simulator'),noise_model=noise_model,shots=10000).result().get_counts())"
    ]
   },
   {
@@ -257,7 +257,7 @@
     "          [0],\n",
     "          [5000]]\n",
     "\n",
-    "Cnoisy = np.dot( M, Cideal)\n",
+    "Cnoisy = np.dot(M, Cideal)\n",
     "print('C_noisy =\\n',Cnoisy)"
    ]
   },
@@ -295,7 +295,6 @@
    "source": [
     "import scipy.linalg as la\n",
     "\n",
-    "\n",
     "M = [[0.9808,0.0107,0.0095,0.0001],\n",
     "    [0.0095,0.9788,0.0001,0.0107],\n",
     "    [0.0096,0.0002,0.9814,0.0087],\n",
@@ -331,7 +330,7 @@
     }
    ],
    "source": [
-    "Cmitigated = np.dot( Minv, Cnoisy)\n",
+    "Cmitigated = np.dot(Minv, Cnoisy)\n",
     "print('C_mitigated =\\n',Cmitigated)"
    ]
   },
@@ -384,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qr = qiskit.QuantumRegister(2)\n",
+    "qr = QuantumRegister(2)\n",
     "meas_calibs, state_labels = complete_meas_cal(qr=qr, circlabel='mcal')"
    ]
   },
@@ -472,8 +471,8 @@
    "outputs": [],
    "source": [
     "# Execute the calibration circuits without noise\n",
-    "backend = qiskit.Aer.get_backend('qasm_simulator')\n",
-    "job = qiskit.execute(meas_calibs, backend=backend, shots=1000)\n",
+    "backend = Aer.get_backend('qasm_simulator')\n",
+    "job = execute(meas_calibs, backend=backend, shots=1000)\n",
     "cal_results = job.result()"
    ]
   },
@@ -547,8 +546,8 @@
     }
    ],
    "source": [
-    "backend = qiskit.Aer.get_backend('qasm_simulator')\n",
-    "job = qiskit.execute(meas_calibs, backend=backend, shots=1000, noise_model=noise_model)\n",
+    "backend = Aer.get_backend('qasm_simulator')\n",
+    "job = execute(meas_calibs, backend=backend, shots=1000, noise_model=noise_model)\n",
     "cal_results = job.result()\n",
     "\n",
     "meas_fitter = CompleteMeasFitter(cal_results, state_labels, circlabel='mcal')\n",
@@ -559,7 +558,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This time we find a more interesting matrix, and one that is not invertible. Let's see how well we can mitigate for this noise. Again, let's use the Bell state $(\\left|00\\right\\rangle+\\left|11\\right\\rangle)/\\sqrt{2}$ for our test."
+    "This time we find a more interesting matrix, and one that we cannot use in the approach that we described earlier. Let's see how well we can mitigate for this noise. Again, let's use the Bell state $(\\left|00\\right\\rangle+\\left|11\\right\\rangle)/\\sqrt{2}$ for our test."
    ]
   },
   {
@@ -581,7 +580,7 @@
     "qc.cx(0,1)  \n",
     "qc.measure(qc.qregs[0],qc.cregs[0])\n",
     "\n",
-    "results = qiskit.execute(qc, backend=backend, shots=10000, noise_model=noise_model).result()\n",
+    "results = execute(qc, backend=backend, shots=10000, noise_model=noise_model).result()\n",
     "\n",
     "noisy_counts = results.get_counts()\n",
     "print(noisy_counts)"
@@ -1681,8 +1680,7 @@
     }
    ],
    "source": [
-    "from qiskit.visualization import *\n",
-    "%config InlineBackend.figure_format = 'svg' # Makes the images look nice\n",
+    "from qiskit.visualization import plot_histogram \n",
     "plot_histogram([noisy_counts, mitigated_counts], legend=['noisy', 'mitigated'])"
    ]
   },
@@ -1743,7 +1741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
**Before**: This time we find a more interesting matrix, and one that is not invertible.
**After**: This time we find a more interesting matrix, and one that we cannot use in the approach that we described earlier.

Also corrected some code semantics where qiskit is imported as `from qiskit import *`. But in some places, code such as 
```python
backend = qiskit.Aer.get_backend('qasm_simulator')
job = qiskit.execute(meas_calibs, backend=backend, shots=1000)
```

has been used instead of
```python
backend = Aer.get_backend('qasm_simulator')
job = execute(meas_calibs, backend=backend, shots=1000)
```
which is more popularly used.

I also changed `from qiskit import *` to
```python
from qiskit import QuantumRegister, QuantumCircuit, Aer, execute
```
for the sake of only importing modules that are actually used.


# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
As described in issue #731, I paraphrased the part where it says that the matrix is not invertible in the sense that the basic method of error mitigation cannot be used. The novice reader is likely to be confused, since one could take it to be that the inverse of the matrix does not exist, when really it is not the case.
