### PR TITLE
3.10 Fix incorrect wording about reflection around the state s.

### DIFF
--- a/content/ch-algorithms/grover.ipynb
+++ b/content/ch-algorithms/grover.ipynb
@@ -236,7 +236,7 @@
     "\n",
     "$$H^{\\otimes n}|s\\rangle = |0\\rangle$$\n",
     "\n",
-    "Then we apply a circuit that adds a negative phase only to the state $|0\\rangle$:\n",
+    "Then we apply a circuit that adds a negative phase to the states orthogonal to $|0\\rangle$:\n",
     "\n",
     "$$U_0 \\frac{1}{2}\\left( \\lvert 00 \\rangle + \\lvert 01 \\rangle + \\lvert 10 \\rangle + \\lvert 11 \\rangle \\right) = \\frac{1}{2}\\left( \\lvert 00 \\rangle - \\lvert 01 \\rangle - \\lvert 10 \\rangle - \\lvert 11 \\rangle \\right)$$\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Changed wording from adding a negative phase to the state `0` to adding a negative phase to every state **except** 0.
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
Unless my understanding is incorrect, after transforming the state `|s>` to `|0>`, we apply a negative phase to every state **except** `|0>`, and leave that untouched. 
An example of the operator can be described as follows:
| 1 | 0  | 0  | 0  | 0  |
|---|----|----|----|----|
| 0 | -1 | 0  | 0  | 0  |
| 0 | 0  | -1 | 0  | 0  |
| 0 | 0  | 0  | -1 | 0  |
| 0 | 0  | 0  | 0  | -1 |

In this operator, the state `0` is left untouched, and every state orthogonal to it has a negative phase.