### PR TITLE
Update bernstein-vazirani.ipynb

### DIFF
--- a/content/ch-algorithms/bernstein-vazirani.ipynb
+++ b/content/ch-algorithms/bernstein-vazirani.ipynb
@@ -2754,8 +2754,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "2. The above [implementation](#implementation) of Bernstein-Vazirani is for a secret bit string $s = 11$. Modify the implementation for a secret string $s = 1011$. Are the results what you expect? Explain.\n",
-    "3. The above [implementation](#implementation) of Bernstein-Vazirani is for a secret bit string $s = 11$. Modify the implementation for a secret string $s = 11101101$. Are the results what you expect? Explain."
+    "2. The above [implementation](#implementation) of Bernstein-Vazirani is for a secret bit string $s = 011$. Modify the implementation for a secret string $s = 1011$. Are the results what you expect? Explain.\n",
+    "3. The above [implementation](#implementation) of Bernstein-Vazirani is for a secret bit string $s = 011$. Modify the implementation for a secret string $s = 11101101$. Are the results what you expect? Explain."
    ]
   },
   {


### PR DESCRIPTION
The secret string given is actually s=011 in the python code. But it is written as s=11 in the Exercise 1 and 2. Although we can argue that 011 and 11 are equivalent in value as they both correspond to decimal value 3, but i think since it is a string then we must write s=011 in the exercise as the string 11 and 011 aren't equivalent.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
