### PR TITLE
[4.1.4] Mention best classical algorithms in Grover/SAT

### DIFF
--- a/content/ch-applications/satisfiability-grover.ipynb
+++ b/content/ch-applications/satisfiability-grover.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "In computer science, the Boolean satisfiability problem is the problem of determining if there exists an interpretation that satisfies a given Boolean formula. In other words, it asks whether the variables of a given Boolean formula can be consistently replaced by the values TRUE or FALSE in such a way that the formula evaluates to TRUE. If this is the case, the formula is called satisfiable. On the other hand, if no such assignment exists, the function expressed by the formula is FALSE for all possible variable assignments and the formula is unsatisfiable. This can be seen as a search problem, where the solution is the assignment where the Boolean formula is satisfied.\n",
     "\n",
-    "For _unstructured_ search problems, Grover’s algorithm is believed to be optimal with its run time of $O(sqrtN) = O(2^n/2) = O(1.414^n)$. In this chapter, we will look at solving a specific Boolean satisfiability problem (3-Satisfiability) using Grover’s algorithm, with the aforementioned run time of $O(1.414^n)$. Interestingly, at the time of writing, the best-known classical algorithm for 3-Satisfiability has an upper-bound of $O(1.307^n)$[2]. You may have heard that Grover’s algorithm can be used to speed up solutions to NP-complete problems, but these NP-complete problems do actually contain structure[3] and we can sometimes do better than the $O(1.414^n)$ of Grover’s algorithm.\n",
+    "For _unstructured_ search problems, Grover’s algorithm is optimal with its run time of $O(\\sqrt{N}) = O(2^{n/2}) = O(1.414^n)$[2]. In this chapter, we will look at solving a specific Boolean satisfiability problem (3-Satisfiability) using Grover’s algorithm, with the aforementioned run time of $O(1.414^n)$. Interestingly, at the time of writing, the best-known classical algorithm for 3-Satisfiability has an upper-bound of $O(1.307^n)$[3]. You may have heard that Grover’s algorithm can be used to speed up solutions to NP-complete problems, but these NP-complete problems do actually contain structure[4] and we can sometimes do better than the $O(1.414^n)$ of Grover’s algorithm.\n",
     "\n",
     "While it doesn’t make sense to use Grover’s algorithm on 3-sat problems, the techniques here can be applied to the more general case (k-SAT, discussed in the next section) for which Grover’s algorithm can outperform the best classical algorithm. Additionally, the techniques in Grover’s algorithm can theoretically be combined with the techniques used in the classical algorithms to gain an even better run time than either individually. "
    ]
@@ -64,7 +64,7 @@
     "\n",
     "\n",
     "\n",
-    "In the above function, the terms on the right-hand side equation which are inside $()$ are called clauses; this function has 5 clauses. Being a 3SAT problem, each clause has exactly three literals. For instance, the first clause has $\\neg v_1$, $\\neg v_2$ and $\\neg v_3$ as its literals. The symbol $\\neg$ is the Boolean NOT that negates (or, flips) the value of its succeeding literal. The symbols $\\vee$ and $\\wedge$ are, respectively, the Boolean OR and AND. The Boolean $f$ is satisfiable if there is an assignment of $v_1, v_2, v_3$ that evaluates to $f(v_1, v_2, v_3) = 1$ (that is, $f$ evaluates to True).\n",
+    "In the above function, the terms on the right-hand side equation which are inside $()$ are called clauses; this function has 5 clauses. In a k-SAT problem, each clause has exactly k literals; our problem is a 3-SAT problem, so each clause has exactly three literals. For instance, the first clause has $\\neg v_1$, $\\neg v_2$ and $\\neg v_3$ as its literals. The symbol $\\neg$ is the Boolean NOT that negates (or, flips) the value of its succeeding literal. The symbols $\\vee$ and $\\wedge$ are, respectively, the Boolean OR and AND. The Boolean $f$ is satisfiable if there is an assignment of $v_1, v_2, v_3$ that evaluates to $f(v_1, v_2, v_3) = 1$ (that is, $f$ evaluates to True).\n",
     "\n",
     "A naive way to find such an assignment is by trying every possible combinations of input values of $f$. Below is the table obtained from trying all possible combinations of $v_1, v_2, v_3$. For ease of explanation, we interchangeably use $0$ and False, as well as $1$ and True.  \n",
     "\n",
@@ -1244,9 +1244,11 @@
     "\n",
     "1. Giacomo Nannicini (2017), _\"An Introduction to Quantum Computing, Without the Physics\",_ [arXiv:1708.03684 ](https://arxiv.org/abs/1708.03684)\n",
     "\n",
-    "2. T. D. Hansen, H. Kaplan, O. Zamir, U. Zwick, _\"Faster k-SAT algorithms using biased-PPSZ\",_ [https://dl.acm.org/doi/10.1145/3313276.3316359](https://dl.acm.org/doi/10.1145/3313276.3316359)\n",
+    "2. Christof Zalka (1997) _\"Grover’s quantum searching algorithm is optimal\",_ [arXiv:quant-ph/9711070](https://arxiv.org/pdf/quant-ph/9711070.pdf)\n",
     "\n",
-    "3. N. J. Cerf, L. K. Grover, C. P. Williams, _\"Nested quantum search and NP-complete problems\",_ [arXiv:quant-ph/9806078](https://arxiv.org/pdf/quant-ph/9806078.pdf)"
+    "3. T. D. Hansen, H. Kaplan, O. Zamir, U. Zwick, _\"Faster k-SAT algorithms using biased-PPSZ\",_ [https://dl.acm.org/doi/10.1145/3313276.3316359](https://dl.acm.org/doi/10.1145/3313276.3316359)\n",
+    "\n",
+    "4. N. J. Cerf, L. K. Grover, C. P. Williams, _\"Nested quantum search and NP-complete problems\",_ [arXiv:quant-ph/9806078](https://arxiv.org/pdf/quant-ph/9806078.pdf)"
    ]
   },
   {

--- a/content/ch-applications/satisfiability-grover.ipynb
+++ b/content/ch-applications/satisfiability-grover.ipynb
@@ -41,9 +41,13 @@
    "source": [
     "## 1. Introduction <a id='introduction'></a>\n",
     "\n",
-    "Grover's algorithm for unstructured search was introduced in an [earlier section](../ch-algorithms/grover.ipynb), with an example and implementation using Qiskit Terra. We saw that Grover search is a quantum algorithm that can be used to search for correct solutions quadratically faster than its classical counterparts. Here, we are going to illustrate the use of Grover's algorithm to solve a particular combinatorial Boolean satisfiability problem. \n",
+    "Grover's algorithm for unstructured search was introduced in an [earlier section](../ch-algorithms/grover.ipynb), with an example and implementation using Qiskit Terra. We saw that Grover search is a quantum algorithm that can be used to search for solutions to unstructured problems quadratically faster than its classical counterparts. Here, we are going to illustrate the use of Grover's algorithm to solve a particular combinatorial Boolean satisfiability problem.\n",
     "\n",
-    "In computer science, the Boolean satisfiability problem is the problem of determining if there exists an interpretation that satisfies a given Boolean formula. In other words, it asks whether the variables of a given Boolean formula can be consistently replaced by the values TRUE or FALSE in such a way that the formula evaluates to TRUE. If this is the case, the formula is called satisfiable. On the other hand, if no such assignment exists, the function expressed by the formula is FALSE for all possible variable assignments and the formula is unsatisfiable. This can be seen as a search problem, where the solution is the assignment where the Boolean formula is satisfied. "
+    "In computer science, the Boolean satisfiability problem is the problem of determining if there exists an interpretation that satisfies a given Boolean formula. In other words, it asks whether the variables of a given Boolean formula can be consistently replaced by the values TRUE or FALSE in such a way that the formula evaluates to TRUE. If this is the case, the formula is called satisfiable. On the other hand, if no such assignment exists, the function expressed by the formula is FALSE for all possible variable assignments and the formula is unsatisfiable. This can be seen as a search problem, where the solution is the assignment where the Boolean formula is satisfied.\n",
+    "\n",
+    "For _unstructured_ search problems, Grover’s algorithm is believed to be optimal with its run time of $O(sqrtN) = O(2^n/2) = O(1.414^n)$. In this chapter, we will look at solving a specific Boolean satisfiability problem (3-Satisfiability) using Grover’s algorithm, with the aforementioned run time of $O(1.414^n)$. Interestingly, at the time of writing, the best-known classical algorithm for 3-Satisfiability has an upper-bound of $O(1.307^n)$[2]. You may have heard that Grover’s algorithm can be used to speed up solutions to NP-complete problems, but these NP-complete problems do actually contain structure[3] and we can sometimes do better than the $O(1.414^n)$ of Grover’s algorithm.\n",
+    "\n",
+    "While it doesn’t make sense to use Grover’s algorithm on 3-sat problems, the techniques here can be applied to the more general case (k-SAT, discussed in the next section) for which Grover’s algorithm can outperform the best classical algorithm. Additionally, the techniques in Grover’s algorithm can theoretically be combined with the techniques used in the classical algorithms to gain an even better run time than either individually. "
    ]
   },
   {
@@ -1238,7 +1242,11 @@
    "source": [
     "## 5. References <a id='references'></a>\n",
     "\n",
-    "1. Giacomo Nannicini (2017), \"An Introduction to Quantum Computing, Without the Physics\", [arXiv:1708.03684 ](https://arxiv.org/abs/1708.03684)"
+    "1. Giacomo Nannicini (2017), _\"An Introduction to Quantum Computing, Without the Physics\",_ [arXiv:1708.03684 ](https://arxiv.org/abs/1708.03684)\n",
+    "\n",
+    "2. T. D. Hansen, H. Kaplan, O. Zamir, U. Zwick, _\"Faster k-SAT algorithms using biased-PPSZ\",_ [https://dl.acm.org/doi/10.1145/3313276.3316359](https://dl.acm.org/doi/10.1145/3313276.3316359)\n",
+    "\n",
+    "3. N. J. Cerf, L. K. Grover, C. P. Williams, _\"Nested quantum search and NP-complete problems\",_ [arXiv:quant-ph/9806078](https://arxiv.org/pdf/quant-ph/9806078.pdf)"
    ]
   },
   {


### PR DESCRIPTION
# Changes made
Mentioned best classical algorithms so that the reader does not believe Grover beats best classical algorithm at 3-SAT. Elaborated on the relationship between Grover search and Boolean satisfiability.

# Justification
see #778
