### PR TITLE
[2.3 Phase Kickback] Use HTML lists instead of markdown (fixes #788)

### DIFF
--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -41370,18 +41370,21 @@
     "\n",
     "### Quick Exercises:\n",
     "\n",
-    "1.\tWhat would be the resulting state of the control qubit (q0) if the target qubit (q1) was in the state $|0\\rangle$? (as shown in the circuit below)? Use Qiskit to check your answer.\n",
-    "\n",
+    "<ol>\n",
+    "<li>What would be the resulting state of the control qubit (q0) if the target qubit (q1) was in the state $|0\\rangle$? (as shown in the circuit below)? Use Qiskit to check your answer.\n",
+    "<br>\n",
     "<img src=\"images/pkb_ex1.svg\">\n",
-    "\n",
-    "2. What would happen to the control qubit (q0) if the if the target qubit (q1) was in the state $|1\\rangle$, and the circuit used a controlled-Sdg gate instead of the controlled-T (as shown in the circuit below)?\n",
-    "\n",
+    "</li>\n",
+    "<li>What would happen to the control qubit (q0) if the if the target qubit (q1) was in the state $|1\\rangle$, and the circuit used a controlled-Sdg gate instead of the controlled-T (as shown in the circuit below)?\n",
+    "<br>\n",
     "<img src=\"images/pkb_ex2.svg\">\n",
+    "</li>\n",
     "\n",
-    "\n",
-    "3. What would happen to the control qubit (q0) if it was in the state $|1\\rangle$ instead of the state $|{+}\\rangle$ before application of the controlled-T (as shown in the circuit below)?\n",
-    "\n",
-    "<img src=\"images/pkb_ex3.svg\">"
+    "<li>What would happen to the control qubit (q0) if it was in the state $|1\\rangle$ instead of the state $|{+}\\rangle$ before application of the controlled-T (as shown in the circuit below)?\n",
+    "<br>\n",
+    "<img src=\"images/pkb_ex3.svg\">\n",
+    "</li>\n",
+    "</ol>"
    ]
   },
   {
@@ -41427,7 +41430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
Used HTML lists instead of markdown lists for the 'quick exercises' section at the bottom of the page

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
Markdown lists were not rendering properly due to the images between the list items
