### PR TITLE
update mathjax

### DIFF
--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -26,4 +26,4 @@ MathJax.Hub.Config({
     {% endif %}
 });
 </script>
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' async></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML-full,Safe' async></script>


### PR DESCRIPTION
updating the MathJax js library seems to resolve the rendering of double-struck I character:

<img width="230" alt="image" src="https://user-images.githubusercontent.com/13156555/98091824-ec451000-1e53-11eb-9bd1-d16275b1cffa.png">


Fixes #768

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made

updated mathjax js library from 2.7.5 to 2.7.7

# Justification

double-struck I was not being properly rendered with the current mathjax js library being used. updated to similar version as referenced in nbconvert (https://github.com/jupyter/nbconvert/blob/master/share/jupyter/nbconvert/templates/base/mathjax.html.j2#L2)
