### PR TITLE
4.1.3 Fixed misspelling of 'discreet' -> discrete

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "\n",
     "\n",
-    "where $x \\in S$, is a discreet variable and $C : D \\rightarrow \\mathbb{R}$ is the cost function. That maps from some domain $S$ in to the real numbers $\\mathbb{R}$. The variable $x$ can be subject to a set of constraints and lies within the set $S \\subset D$ of feasible points.\n",
+    "where $x \\in S$, is a discrete variable and $C : D \\rightarrow \\mathbb{R}$ is the cost function. That maps from some domain $S$ in to the real numbers $\\mathbb{R}$. The variable $x$ can be subject to a set of constraints and lies within the set $S \\subset D$ of feasible points.\n",
     "\n",
     "In binary combinatorial optimization problems, the cost function can typically be expressed as a sum of terms that only involve a subset $Q \\subset[n]$ of the $n$ bits in the string $x \\in \\{0,1\\}^n$ . The cost function $C$ typically written in the canonical form\n",
     "\n",


### PR DESCRIPTION
# Changes made
It's discrete variable, not discreet

# Justification
https://en.wikipedia.org/wiki/Continuous_or_discrete_variable
https://www.grammarly.com/blog/discreet-discrete/#:~:text=Discreet%20and%20discrete%20are%20homophones,Discrete%20means%20distinct%20or%20unconnected.