### PR TITLE
4.1.1 Fixed math typo

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -154,7 +154,7 @@
     "$$\n",
     "Then, for the eigenvector $|u_{j}\\rangle_{n_{b}}$, which has eigenvalue $e ^ { i \\lambda _ { j } t }$, QPE will output $|\\tilde{\\lambda }_ { j }\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}$. Where $\\tilde{\\lambda }_ { j }$ represents an $n_{l}$-bit binary approximation to $2^{n_l}\\frac{\\lambda_ { j }t}{2\\pi}$. Therefore, if each $\\lambda_{j}$ can be exactly represented with $n_{l}$ bits,\n",
     "$$\n",
-    "\\operatorname { QPE } ( e ^ { i A 2\\pi } , \\sum_{j=0}^{N-1}b_{j}|0\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}} ) = \\sum_{j=0}^{N-1}b_{j}|\\lambda_{j}\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}.\n",
+    "\\operatorname { QPE } ( e ^ { i A t } , \\sum_{j=0}^{N-1}b_{j}|0\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}} ) = \\sum_{j=0}^{N-1}b_{j}|\\lambda_{j}\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}.\n",
     "$$"
    ]
   },


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

Changed e^{i A 2\pi} to e^{i A t} 

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->

The input to the QPE algorithm particular to HHL involves using the unitary operator e^{i A t}.
