### PR TITLE
Fix cu1 deprecation

### DIFF
--- a/content/ch-algorithms/quantum-counting.ipynb
+++ b/content/ch-algorithms/quantum-counting.ipynb
@@ -262,7 +262,7 @@
     "        n -= 1\n",
     "        circuit.h(n)\n",
     "        for qubit in range(n):\n",
-    "            circuit.cu1(np.pi/2**(n-qubit), qubit, n)\n",
+    "            circuit.p(np.pi/2**(n-qubit), qubit, n)\n",
     "        qft_rotations(circuit, n)\n",
     "    \n",
     "    qft_rotations(circuit, n)\n",

--- a/content/ch-algorithms/quantum-fourier-transform.ipynb
+++ b/content/ch-algorithms/quantum-fourier-transform.ipynb
@@ -1109,7 +1109,7 @@
     }
    ],
    "source": [
-    "qc.cu1(pi/2, 1, 2) # CROT from qubit 1 to qubit 2\n",
+    "qc.p(pi/2, 1, 2) # CROT from qubit 1 to qubit 2\n",
     "qc.draw('mpl')"
    ]
   },
@@ -1513,7 +1513,7 @@
     }
    ],
    "source": [
-    "qc.cu1(pi/4, 0, 2) # CROT from qubit 2 to qubit 0\n",
+    "qc.p(pi/4, 0, 2) # CROT from qubit 2 to qubit 0\n",
     "qc.draw('mpl')"
    ]
   },
@@ -1996,7 +1996,7 @@
    ],
    "source": [
     "qc.h(1)\n",
-    "qc.cu1(pi/2, 0, 1) # CROT from qubit 0 to qubit 1\n",
+    "qc.p(pi/2, 0, 1) # CROT from qubit 0 to qubit 1\n",
     "qc.h(0)\n",
     "qc.draw('mpl')"
    ]
@@ -2533,7 +2533,7 @@
     "    for qubit in range(n):\n",
     "        # For each less significant qubit, we need to do a\n",
     "        # smaller-angled controlled rotation: \n",
-    "        circuit.cu1(pi/2**(n-qubit), qubit, n)"
+    "        circuit.p(pi/2**(n-qubit), qubit, n)"
    ]
   },
   {
@@ -3850,7 +3850,7 @@
     "    n -= 1\n",
     "    circuit.h(n)\n",
     "    for qubit in range(n):\n",
-    "        circuit.cu1(pi/2**(n-qubit), qubit, n)\n",
+    "        circuit.p(pi/2**(n-qubit), qubit, n)\n",
     "    # At the end of our function, we call the same function again on\n",
     "    # the next qubits (we reduced n by one earlier in the function)\n",
     "    qft_rotations(circuit, n)\n",

--- a/content/ch-algorithms/quantum-phase-estimation.ipynb
+++ b/content/ch-algorithms/quantum-phase-estimation.ipynb
@@ -1751,7 +1751,7 @@
     "repetitions = 1\n",
     "for counting_qubit in range(3):\n",
     "    for i in range(repetitions):\n",
-    "        qpe.cu1(math.pi/4, counting_qubit, 3); # This is C-U\n",
+    "        qpe.p(math.pi/4, counting_qubit, 3); # This is C-U\n",
     "    repetitions *= 2\n",
     "qpe.draw()"
    ]
@@ -1776,7 +1776,7 @@
     "        circ.swap(qubit, n-qubit-1)\n",
     "    for j in range(n):\n",
     "        for m in range(j):\n",
-    "            circ.cu1(-math.pi/float(2**(j-m)), m, j)\n",
+    "            circ.p(-math.pi/float(2**(j-m)), m, j)\n",
     "        circ.h(j)"
    ]
   },
@@ -5002,7 +5002,7 @@
     "repetitions = 1\n",
     "for counting_qubit in range(3):\n",
     "    for i in range(repetitions):\n",
-    "        qpe2.cu1(angle, counting_qubit, 3);\n",
+    "        qpe2.p(angle, counting_qubit, 3);\n",
     "    repetitions *= 2\n",
     "\n",
     "# Do the inverse QFT:\n",
@@ -9339,7 +9339,7 @@
     "repetitions = 1\n",
     "for counting_qubit in range(5):\n",
     "    for i in range(repetitions):\n",
-    "        qpe3.cu1(angle, counting_qubit, 5);\n",
+    "        qpe3.p(angle, counting_qubit, 5);\n",
     "    repetitions *= 2\n",
     "\n",
     "# Do the inverse QFT:\n",

--- a/content/ch-algorithms/shor.ipynb
+++ b/content/ch-algorithms/shor.ipynb
@@ -2596,7 +2596,7 @@
     "        qc.swap(qubit, n-qubit-1)\n",
     "    for j in range(n):\n",
     "        for m in range(j):\n",
-    "            qc.cu1(-np.pi/float(2**(j-m)), m, j)\n",
+    "            qc.p(-np.pi/float(2**(j-m)), m, j)\n",
     "        qc.h(j)\n",
     "    qc.name = \"QFT†\"\n",
     "    return qc"

--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -154,7 +154,7 @@
     "$$\n",
     "Then, for the eigenvector $|u_{j}\\rangle_{n_{b}}$, which has eigenvalue $e ^ { i \\lambda _ { j } t }$, QPE will output $|\\tilde{\\lambda }_ { j }\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}$. Where $\\tilde{\\lambda }_ { j }$ represents an $n_{l}$-bit binary approximation to $2^{n_l}\\frac{\\lambda_ { j }t}{2\\pi}$. Therefore, if each $\\lambda_{j}$ can be exactly represented with $n_{l}$ bits,\n",
     "$$\n",
-    "\\operatorname { QPE } ( e ^ { i A 2\\pi } , \\sum_{j=0}^{N-1}b_{j}|0\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}} ) = \\sum_{j=0}^{N-1}b_{j}|\\lambda_{j}\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}\n",
+    "\\operatorname { QPE } ( e ^ { i A t } , \\sum_{j=0}^{N-1}b_{j}|0\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}} ) = \\sum_{j=0}^{N-1}b_{j}|\\lambda_{j}\\rangle_{n_{l}}|u_{j}\\rangle_{n_{b}}\n",
     "$$"
    ]
   },

--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -9010,7 +9010,7 @@
     "for edge in E:\n",
     "    k = edge[0]\n",
     "    l = edge[1]\n",
-    "    QAOA.cu1(-2*gamma, k, l)\n",
+    "    QAOA.p(-2*gamma, k, l)\n",
     "    QAOA.u1(gamma, k)\n",
     "    QAOA.u1(gamma, l)\n",
     "    \n",

--- a/content/ch-demos/piday-code.ipynb
+++ b/content/ch-demos/piday-code.ipynb
@@ -101,7 +101,7 @@
     "        circ_.swap(qubit, n_qubits-qubit-1)\n",
     "    for j in range(0,n_qubits):\n",
     "        for m in range(j):\n",
-    "            circ_.cu1(-np.pi/float(2**(j-m)), m, j)\n",
+    "            circ_.p(-np.pi/float(2**(j-m)), m, j)\n",
     "        circ_.h(j)"
    ]
   },
@@ -129,7 +129,7 @@
     "\n",
     "    for x in reversed(range(n_qubits)):\n",
     "        for _ in range(2**(n_qubits-1-x)):\n",
-    "            circ_.cu1(1, n_qubits-1-x, n_qubits)"
+    "            circ_.p(1, n_qubits-1-x, n_qubits)"
    ]
   },
   {

--- a/content/ch-gates/more-circuit-identities.ipynb
+++ b/content/ch-gates/more-circuit-identities.ipynb
@@ -3972,7 +3972,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To see how to build it from single- and two-qubit gates, it is helpful to first show how to build something even more general: an arbitrary controlled-controlled-U for any single-qubit rotation U. For this we need to define controlled versions of $V = \\sqrt{U}$ and $V^\\dagger$. In the code below, we use `cu1(theta,c,t)` and `cu1(-theta,c,t)`in place of the undefined subroutines `cv` and `cvdg` respectively. The controls are qubits $a$ and $b$, and the target is qubit $t$."
+    "To see how to build it from single- and two-qubit gates, it is helpful to first show how to build something even more general: an arbitrary controlled-controlled-U for any single-qubit rotation U. For this we need to define controlled versions of $V = \\sqrt{U}$ and $V^\\dagger$. In the code below, we use `p(theta,c,t)` and `p(-theta,c,t)`in place of the undefined subroutines `cv` and `cvdg` respectively. The controls are qubits $a$ and $b$, and the target is qubit $t$."
    ]
   },
   {
@@ -4457,11 +4457,11 @@
    ],
    "source": [
     "qc = QuantumCircuit(3)\n",
-    "qc.cu1(theta,b,t)\n",
+    "qc.p(theta,b,t)\n",
     "qc.cx(a,b)\n",
-    "qc.cu1(-theta,b,t)\n",
+    "qc.p(-theta,b,t)\n",
     "qc.cx(a,b)\n",
-    "qc.cu1(theta,a,t)\n",
+    "qc.p(theta,a,t)\n",
     "qc.draw()"
    ]
   },

--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -25132,7 +25132,7 @@
    ],
    "source": [
     "qc = QuantumCircuit(2)\n",
-    "qc.cu1(pi/4, 0, 1)\n",
+    "qc.p(pi/4, 0, 1)\n",
     "qc.draw()"
    ]
   },
@@ -25461,7 +25461,7 @@
    ],
    "source": [
     "qc = QuantumCircuit(2)\n",
-    "qc.cu1(pi/4, 0, 1)\n",
+    "qc.p(pi/4, 0, 1)\n",
     "display(qc.draw())\n",
     "# See Results:\n",
     "unitary_backend = Aer.get_backend('unitary_simulator')\n",
@@ -41353,7 +41353,7 @@
     "qc.h(0)\n",
     "qc.x(1)\n",
     "# Add Controlled-T\n",
-    "qc.cu1(pi/4, 0, 1)\n",
+    "qc.p(pi/4, 0, 1)\n",
     "display(qc.draw())\n",
     "# See Results:\n",
     "final_state = execute(qc,statevector_backend).result().get_statevector()\n",

--- a/content/ch-quantum-hardware/transpiling-quantum-circuits.ipynb
+++ b/content/ch-quantum-hardware/transpiling-quantum-circuits.ipynb
@@ -679,7 +679,7 @@
     "\n",
     "qc.h(qr[0])\n",
     "qc.x(qr[1])\n",
-    "qc.cu1(np.pi/4, qr[0], qr[1])\n",
+    "qc.p(np.pi/4, qr[0], qr[1])\n",
     "qc.h(qr[0])\n",
     "qc.measure(qr[0], cr[0])\n",
     "qc.draw(output='mpl')"

--- a/content/widgets-index.ipynb
+++ b/content/widgets-index.ipynb
@@ -184,7 +184,7 @@
     "    n -= 1\n",
     "    circuit.h(n)\n",
     "    for qubit in range(n):\n",
-    "        circuit.cu1(pi/2**(n-qubit), qubit, n)\n",
+    "        circuit.p(pi/2**(n-qubit), qubit, n)\n",
     "    # At the end of our function, we call the same function again on\n",
     "    # the next qubits (we reduced n by one earlier in the function)\n",
     "    qft_rotations(circuit, n)\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

Changed `cu1` to `p` to avoid deprecation warnings, as suggested in #885.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->

In the latest release of qiskit, `cu1` is replaced with `p` and is deprecated. To remove this warning when executing code, this PR has been made.
