### PR TITLE
4.1.4 Fixed dead link

### DIFF
--- a/content/ch-applications/satisfiability-grover.ipynb
+++ b/content/ch-applications/satisfiability-grover.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "## 1. Introduction <a id='introduction'></a>\n",
     "\n",
-    "Grover's algorithm for unstructured search was introduced in an [earlier section](../ch-algorithms/grover.ipynb), with an example and implementation using Qiskit Terra. We saw that Grover search is a quantum algorithm that can be used to search for solutions to unstructured problems quadratically faster than its classical counterparts. Here, we are going to illustrate the use of Grover's algorithm to solve a particular combinatorial Boolean satisfiability problem.\n",
+    "Grover's algorithm for unstructured search was introduced in an [earlier section](https://qiskit.org/textbook/ch-algorithms/grover.html), with an example and implementation using Qiskit Terra. We saw that Grover search is a quantum algorithm that can be used to search for solutions to unstructured problems quadratically faster than its classical counterparts. Here, we are going to illustrate the use of Grover's algorithm to solve a particular combinatorial Boolean satisfiability problem.\n",
     "\n",
     "In computer science, the Boolean satisfiability problem is the problem of determining if there exists an interpretation that satisfies a given Boolean formula. In other words, it asks whether the variables of a given Boolean formula can be consistently replaced by the values TRUE or FALSE in such a way that the formula evaluates to TRUE. If this is the case, the formula is called satisfiable. On the other hand, if no such assignment exists, the function expressed by the formula is FALSE for all possible variable assignments and the formula is unsatisfiable. This can be seen as a search problem, where the solution is the assignment where the Boolean formula is satisfied.\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
Fixes #890 
Changed link in 4.1.4 "Solving Satisfiability Problems using Grover's Algorithm" so it redirects to the appropriate earlier section in the Qiskit Textbook.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
Current link leads to a "Page Not Found." This change makes the link go to the appropriate page in the Qiskit Textbook.
