### PR TITLE
added shots when running simulated experiment (otherwise printed aver…

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -10295,7 +10295,7 @@
     "shots = 10000\n",
     "\n",
     "TQAOA = transpile(QAOA, backend)\n",
-    "qobj = assemble(TQAOA)\n",
+    "qobj = assemble(TQAOA, shots=shots)\n",
     "QAOA_results = backend.run(qobj).result()\n",
     "\n",
     "plot_histogram(QAOA_results.get_counts(),figsize = (8,6),bar_labels = False)"
@@ -13357,9 +13357,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
4.1.3 Solving combinatorial optimization problems using QAOA
Fixed missing shots in the experiment run on simulator

# Changes made
Added the `shots` argument to the `assemble` method

# Justification
The `shots` variable was initialized but not passed as argument. This, among other things, made the computed (and printed) averages wrong.
