### PR TITLE
Lab01 Part2 Fixed misspelling of 'tolerant'

### DIFF
--- a/content/ch-labs/Lab01_QuantumCircuits.ipynb
+++ b/content/ch-labs/Lab01_QuantumCircuits.ipynb
@@ -1039,7 +1039,7 @@
     "              font-size:16px;\">Execute AND gate on two quantum systems and learn how the different circuit properties affect the result.</p>\n",
     "</div>\n",
     "\n",
-    "In Part 1 you made an `AND` gate from quantum gates, and executed it on the simulator.  Here in Part 2 you will do it again, but instead run the circuits on a real quantum computer.  When using a real quantum system, one thing you should keep in mind is that present day quantum computers are not fault tolerent; they are noisy.\n",
+    "In Part 1 you made an `AND` gate from quantum gates, and executed it on the simulator.  Here in Part 2 you will do it again, but instead run the circuits on a real quantum computer.  When using a real quantum system, one thing you should keep in mind is that present day quantum computers are not fault tolerant; they are noisy.\n",
     "\n",
     "The 'noise' in a quantum system is the collective effects of all the things that should not happen, but nevertheless do. Noise results in outputs are not always what we would expect. There is noise associated with all processes in a quantum circuit: preparing the initial state, applying gates, and qubit measurement.  For the gates, noise levels can vary between different gates and between different qubits. `cx` gates are typically more noisy than any single qubit gate.\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

Changed the spelling of 'tolerent'[sic] to 'tolerant' in Lab01 Part2

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

