### PR TITLE
Lab01 Part2.1 Fixed misspelling of 'triangular'

### DIFF
--- a/content/ch-labs/Lab01_QuantumCircuits.ipynb
+++ b/content/ch-labs/Lab01_QuantumCircuits.ipynb
@@ -1168,7 +1168,7 @@
    "source": [
     "Real quantum computers need to be recalibrated regularly, and the fidelity of a specific qubit or gate can change over time. Therefore, which system would produce results with less error can vary. `ibmq_athens` tends to show relatively low error rates.\n",
     "\n",
-    "In this exercise, we select two systems: `ibmq_athens` for its low error rates, and `ibmqx2` for its additional connectivity, in particular is triganular connectivity, that will be useful for circuits with Toffoli gates."
+    "In this exercise, we select two systems: `ibmq_athens` for its low error rates, and `ibmqx2` for its additional connectivity, in particular its triangular connectivity, that will be useful for circuits with Toffoli gates."
    ]
   },
   {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

In Lab01 Part2.1 changed spelling of '[...] is triganular [...]' to '[...] its triangular [...]'

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
