### PR TITLE
fixed issue 954 by replacing state labels and coefficients in markdow…

### DIFF
--- a/content/ch-algorithms/teleportation.ipynb
+++ b/content/ch-algorithms/teleportation.ipynb
@@ -22383,19 +22383,19 @@
     "\n",
     "#### Step 1\n",
     "\n",
-    "Quantum Teleportation begins with the fact that Alice needs to transmit $|q\\rangle = a|0\\rangle + b|1\\rangle$ (a random qubit) to Bob. She doesn't know the state of the qubit. For this, Alice and Bob take the help of a third party (Telamon). Telamon prepares a pair of entangled qubits for Alice and Bob. The entangled qubits could be written in Dirac Notation as:\n",
+    "Quantum Teleportation begins with the fact that Alice needs to transmit $|\\psi\\rangle = \\alpha|0\\rangle + \\beta|1\\rangle$ (a random qubit) to Bob. She doesn't know the state of the qubit. For this, Alice and Bob take the help of a third party (Telamon). Telamon prepares a pair of entangled qubits for Alice and Bob. The entangled qubits could be written in Dirac Notation as:\n",
     "\n",
-    "$$ |\\psi \\rangle = \\frac{1}{\\sqrt{2}} (|00\\rangle + |11\\rangle) $$\n",
+    "$$ |e \\rangle = \\frac{1}{\\sqrt{2}} (|00\\rangle + |11\\rangle) $$\n",
     "\n",
     "Alice and Bob each possess one qubit of the entangled pair (denoted as A and B respectively),\n",
     "\n",
-    "$$|\\psi\\rangle = \\frac{1}{\\sqrt{2}} (|0\\rangle_A |0\\rangle_B + |1\\rangle_A |1\\rangle_B) $$\n",
+    "$$|e\\rangle = \\frac{1}{\\sqrt{2}} (|0\\rangle_A |0\\rangle_B + |1\\rangle_A |1\\rangle_B) $$\n",
     "\n",
     "This creates a three qubit quantum system where Alice has the first two qubits and Bob the last one.\n",
     "\n",
     "$$ \\begin{align*}\n",
-    "|q\\rangle \\otimes |\\psi\\rangle &= \\frac{1}{\\sqrt{2}} (a |0\\rangle \\otimes (|00\\rangle + |11\\rangle) + b |1\\rangle \\otimes (|00\\rangle + |11\\rangle))\\\\\n",
-    "&= \\frac{1}{\\sqrt{2}} (a|000\\rangle + a|011\\rangle + b|100\\rangle + b|111\\rangle) \n",
+    "|\\psi\\rangle \\otimes |e\\rangle &= \\frac{1}{\\sqrt{2}} (\\alpha |0\\rangle \\otimes (|00\\rangle + |11\\rangle) + \\beta |1\\rangle \\otimes (|00\\rangle + |11\\rangle))\\\\\n",
+    "&= \\frac{1}{\\sqrt{2}} (\\alpha|000\\rangle + \\alpha|011\\rangle + \\beta|100\\rangle + \\beta|111\\rangle) \n",
     "\\end{align*}$$"
    ]
   },
@@ -22408,10 +22408,10 @@
     "Now according to the protocol Alice applies CNOT gate on her two qubits followed by Hadamard gate on the first qubit. This results in the state:\n",
     "\n",
     "$$ \n",
-    "\\begin{align*} (H \\otimes I \\otimes I) (CNOT \\otimes I) (|q\\rangle \\otimes |\\psi\\rangle)\n",
-    "&=(H \\otimes I \\otimes I) (CNOT \\otimes I) \\frac{1}{\\sqrt{2}} (a|000\\rangle + a|011\\rangle + b|100\\rangle + b|111\\rangle) \\\\\n",
-    "&= (H \\otimes I \\otimes I) \\frac{1}{\\sqrt{2}} (a|000\\rangle + a|011\\rangle + b|110\\rangle + b|101\\rangle) \\\\\n",
-    "&= \\frac{1}{2}  (a(|000\\rangle + |011\\rangle + |100\\rangle + |111\\rangle) + b(|010\\rangle + |001\\rangle - |110\\rangle - |101\\rangle)) \\\\\n",
+    "\\begin{align*} (H \\otimes I \\otimes I) (CNOT \\otimes I) (|\\psi\\rangle \\otimes |e\\rangle)\n",
+    "&=(H \\otimes I \\otimes I) (CNOT \\otimes I) \\frac{1}{\\sqrt{2}} (\\alpha|000\\rangle + \\alpha|011\\rangle + \\beta|100\\rangle + \\beta|111\\rangle) \\\\\n",
+    "&= (H \\otimes I \\otimes I) \\frac{1}{\\sqrt{2}} (\\alpha|000\\rangle + \\alpha|011\\rangle + \\beta|110\\rangle + \\beta|101\\rangle) \\\\\n",
+    "&= \\frac{1}{2}  (\\alpha(|000\\rangle + |011\\rangle + |100\\rangle + |111\\rangle) + \\beta(|010\\rangle + |001\\rangle - |110\\rangle - |101\\rangle)) \\\\\n",
     "\\end{align*}\n",
     "$$\n",
     "\n",
@@ -22420,10 +22420,10 @@
     "$$\n",
     "\\begin{align*}\n",
     "= \\frac{1}{2}(\n",
-    " & \\phantom{+} |00\\rangle (a|0\\rangle + b|1\\rangle) \\hphantom{\\quad )} \\\\\n",
-    " & + |01\\rangle (a|1\\rangle + b|0\\rangle) \\hphantom{\\quad )}\\\\[4pt]\n",
-    " & + |10\\rangle (a|0\\rangle - b|1\\rangle) \\hphantom{\\quad )}\\\\[4pt]\n",
-    " & + |11\\rangle (a|1\\rangle - b|0\\rangle) \\quad )\\\\\n",
+    " & \\phantom{+} |00\\rangle (\\alpha|0\\rangle + \\beta|1\\rangle) \\hphantom{\\quad )} \\\\\n",
+    " & + |01\\rangle (\\alpha|1\\rangle + \\beta|0\\rangle) \\hphantom{\\quad )}\\\\[4pt]\n",
+    " & + |10\\rangle (\\alpha|0\\rangle - \\beta|1\\rangle) \\hphantom{\\quad )}\\\\[4pt]\n",
+    " & + |11\\rangle (\\alpha|1\\rangle - \\beta|0\\rangle) \\quad )\\\\\n",
     "\\end{align*}\n",
     "$$"
    ]
@@ -22437,10 +22437,10 @@
     "Alice measures the first two qubit (which she owns) and sends them as two classical bits to Bob. The result she obtains is always one of the four standard basis states $|00\\rangle, |01\\rangle, |10\\rangle,$ and $|11\\rangle$ with equal probability.  \n",
     "\n",
     "On the basis of her measurement, Bob's state will be projected to, \n",
-    "$$ |00\\rangle \\rightarrow (a|0\\rangle + b|1\\rangle)\\\\\n",
-    "|01\\rangle \\rightarrow (a|1\\rangle + b|0\\rangle)\\\\\n",
-    "|10\\rangle \\rightarrow (a|0\\rangle - b|1\\rangle)\\\\\n",
-    "|11\\rangle \\rightarrow (a|1\\rangle - b|0\\rangle)$$."
+    "$$ |00\\rangle \\rightarrow (\\alpha|0\\rangle + \\beta|1\\rangle)\\\\\n",
+    "|01\\rangle \\rightarrow (\\alpha|1\\rangle + \\beta|0\\rangle)\\\\\n",
+    "|10\\rangle \\rightarrow (\\alpha|0\\rangle - \\beta|1\\rangle)\\\\\n",
+    "|11\\rangle \\rightarrow (\\alpha|1\\rangle - \\beta|0\\rangle)$$."
    ]
   },
   {
@@ -22449,11 +22449,19 @@
    "source": [
     "#### Step 4\n",
     "\n",
-    "Bob, on receiving the bits from Alice, knows he can obtain the original state $|q\\rangle$ by applying appropriate transformations on his qubit that was once part of the entangled pair.\n",
+    "Bob, on receiving the bits from Alice, knows he can obtain the original state $|\\psi\\rangle$ by applying appropriate transformations on his qubit that was once part of the entangled pair.\n",
     "\n",
     "The transformations he needs to apply are:\n",
     "\n",
-    "![title](images/teleportation-transformation.png)\n",
+    "$$\n",
+    "\\begin{array}{c c c}\n",
+    "\\mbox{Bob's State}                 & \\mbox{Bits Received} & \\mbox{Gate Applied} \\\\\n",
+    "(\\alpha|0\\rangle + \\beta|1\\rangle) & 00                   & I                   \\\\\n",
+    "(\\alpha|1\\rangle + \\beta|0\\rangle) & 01                   & X                   \\\\\n",
+    "(\\alpha|0\\rangle - \\beta|1\\rangle) & 10                   & Z                   \\\\\n",
+    "(\\alpha|1\\rangle - \\beta|0\\rangle) & 11                   & ZX\n",
+    "\\end{array}\n",
+    "$$\n",
     "\n",
     "After this step Bob will have successfully reconstructed Alice's state."
    ]
@@ -24395,7 +24403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
3.10, Fixed issue #954 

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
In the section 4. (Understanding Quantum Teleportation) of 3.10, did the following changes in the markdown cells, to make the explanation consistent with text appearing earlier in the same notebook page:
1. Changed the shared entangled state's label from $$|\psi>$$ to $$|e>$$
2. Changed the label for the qubit to be sent by Alice from $$|q>$$ to $$\psi$$
3. Changed the probability amplitudes $$a$$ and $$b$$ to $$\alpha$$ and $$\beta$$ respectively.
4. Replaced the graphic teleportation-transformation.png with a table created via latex array environment.
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
1. Changes 1. and 2. were required because text matter before '4. Understanding Quantum Teleportation' uses $$|\psi>$$ for the qubit to be sent by Alice. However, in '4. Understanding Quantum Teleportation', there was an abrupt and unexplained change of notation to $$|\psi>$$ being used for the shared entangled state and $$|q>$$ being used for qubit to be sent. This was creating an inconsistent notation.
See the following snippets of the 2 subsections in 3.10 in their existing form:
![image](https://user-images.githubusercontent.com/61590679/111919446-07858480-8ab0-11eb-994f-a98fb5614aa2.png)

![image](https://user-images.githubusercontent.com/61590679/111919421-ed4ba680-8aaf-11eb-9e1a-a751d10d1417.png)
2. There was a similar inconsistency in letters being used to denote the probability amplitudes for the qubit to be sent by Alice. Earlier part of 3.10 uses $$\alpha$$ and $$\beta$$, while '4. Understanding Quantum Teleportation' uses the notation $$a$$ and $$b$$. This justifies changes 3. and 4. 
(Pl. refer to the attached snapshots).
3. Further explanation for change 4.: Earlier, there was a graphic teleportation-transformation.png in one markdown cell in '4. Understanding Quantum Teleportation' in 3.10. This png file contained the inconsistent notation $$a$$ and $$b$$. In order to use $$\alpha$$ and $$\beta$$, this png file has been replaced by a table in latex created via array environment. It conveys the same information as the png file, while care has been taken to replace $$a$$ and $$b$$ with $$\alpha$$ and $$\beta$$ respectively.

