### PR TITLE
8.1: math typo in equation finding eigenvalue

### DIFF
--- a/content/ch-appendix/linear_algebra.ipynb
+++ b/content/ch-appendix/linear_algebra.ipynb
@@ -8493,7 +8493,7 @@
     "<br>\n",
     "\n",
     "\n",
-    "$$\\text{det} (\\sigma_z \\ - \\ \\lambda \\mathbb{I}) \\ = \\ \\text{det} \\begin{pmatrix} 1 \\ - \\ \\lambda & 0 \\\\ 0 & -1 \\ - \\ \\lambda \\end{pmatrix}  \\ = \\ (-1 \\ - \\ \\lambda)(1 \\ - \\ \\lambda) \\ = \\ 1 \\ - \\ \\lambda^2 \\ = \\ 0 \\ \\Rightarrow \\ \\lambda \\ = \\ \\pm 1$$\n",
+    "$$\\text{det} (\\sigma_z \\ - \\ \\lambda \\mathbb{I}) \\ = \\ \\text{det} \\begin{pmatrix} 1 \\ - \\ \\lambda & 0 \\\\ 0 & -1 \\ - \\ \\lambda \\end{pmatrix}  \\ = \\ (-1 \\ - \\ \\lambda)(1 \\ - \\ \\lambda) \\ = \\lambda^2\\ - \\ \\ 1 \\ = \\ 0 \\ \\Rightarrow \\ \\lambda \\ = \\ \\pm 1$$\n",
     "\n",
     "\n",
     "<br>\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Original version:
<img width="247" alt="스크린샷 2021-03-22 오후 11 40 15" src="https://user-images.githubusercontent.com/26103841/112020016-5b0cd680-8b73-11eb-805b-80b3878562ed.png">

Changed to:
<img width="213" alt="스크린샷 2021-03-22 오후 11 40 04" src="https://user-images.githubusercontent.com/26103841/112020052-64963e80-8b73-11eb-9f52-8323a632b649.png">


# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The signs of lambda^2 and 1 seem to be swapped.
