### PR TITLE
3.5 Section 5 Fixed indexes wrong/inconsistent indexes

### DIFF
--- a/content/ch-algorithms/quantum-fourier-transform.ipynb
+++ b/content/ch-algorithms/quantum-fourier-transform.ipynb
@@ -228,17 +228,17 @@
     "0&\\exp\\left(\\frac{2\\pi i}{2^k}\\right)\\\\\n",
     "\\end{matrix}\\right]$$\n",
     "\n",
-    "The action of $CROT_k$ on the two-qubit state $\\vert x_jx_k\\rangle$ where the first qubit is the control and the second is the target is given by\n",
+    "The action of $CROT_k$ on a two-qubit state $\\vert x_l x_j\\rangle$ where the first qubit is the control and the second is the target is given by\n",
     "\n",
     "\n",
     "\n",
-    "$$CROT_k\\vert 0x_j\\rangle = \\vert 0x_j\\rangle$$\n",
+    "$$CROT_k\\vert 0 x_j\\rangle = \\vert 0 x_j\\rangle$$\n",
     "\n",
     "\n",
     "and\n",
     "\n",
     "\n",
-    "$$CROT_k\\vert 1x_j\\rangle = \\exp\\left( \\frac{2\\pi i}{2^k}x_j \\right)\\vert 1x_j\\rangle$$\n",
+    "$$CROT_k\\vert 1 x_j\\rangle = \\exp\\left( \\frac{2\\pi i}{2^k}x_j \\right)\\vert 1x_j\\rangle$$\n",
     "\n",
     "\n",
     "\n",
@@ -42088,7 +42088,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.2"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -42631,5 +42631,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
I have fixed indexes of a two-qubit state in Section 5, see issue 964 (also the comments)

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
See the issue 964 and comments. Here the summary
1. In the sentence that starts with "The action of $CROT_k$ on the two-qubit state $\vert x_j x_k\rangle$", the order of the indexes, j and k, of the state $\vert x_j x_k\rangle$ is inconsistent respect to the subsequent 2 mathematical expressions, it is reversed.
2. Furthermore, the index of the state of the first qubit should be different from $k$, the index of $CROT_k$, to be consistent with the index of UROT in the QFT circuit figure in section 5 and the explanation in the steps 1-4.
