### PR TITLE
3.5 Section 5 Fixed indexes wrong/inconsistent indexes

### DIFF
--- a/content/ch-algorithms/quantum-fourier-transform.ipynb
+++ b/content/ch-algorithms/quantum-fourier-transform.ipynb
@@ -228,7 +228,7 @@
     "0&\\exp\\left(\\frac{2\\pi i}{2^k}\\right)\\\\\n",
     "\\end{matrix}\\right]$$\n",
     "\n",
-    "The action of $CROT_k$ on the two-qubit state $\\vert x_jx_k\\rangle$ where the first qubit is the control and the second is the target is given by\n",
+    "The action of $CROT_k$ on a two-qubit state $\\vert x_l x_j\\rangle$ where the first qubit is the control and the second is the target is given by\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
I have fixed indexes of a two-qubit state in Section 5, see issue 964.
In the sentence that starts with "The action of $CROT_k$ on the two-qubit state $\vert x_j x_k\rangle$" I have changed the indexes of the state in $\vert x_l x_j\rangle$

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
See the issue 964 and comments. Here the summary:
1. In the sentence that starts with "The action of $CROT_k$ on the two-qubit state $\vert x_j x_k\rangle$", the order of the indexes, j and k, of the state $\vert x_j x_k\rangle$ is inconsistent respect to the subsequent 2 mathematical expressions, it is reversed.
2. Furthermore, the index of the state of the first qubit should be different from $k$, the index of $CROT_k$, to be consistent with the index of UROT in the QFT circuit figure in section 5 and the explanation in the steps 1-4.