### PR TITLE
Add link to contribution guidelines and update guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ After writing your chapter, you must add a few tags to your cells (You can see t
 For a list of contributors, see the [.bib](https://github.com/qiskit-community/qiskit-textbook/blob/master/content/qiskit-textbook.bib) file.
 
 ## Translation Guidelines
-The multi-language translation guideline will be updated later.
+The multi-language translation guidelines will be updated later.
 
 ### Contributing Guidelines to the Japanese edition of Qiskit Textbook
 #### [日本語翻訳のガイドライン](./i18n/locales/ja/guideline-ja.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,20 @@ After writing your chapter, you must add a few tags to your cells (You can see t
 - Finally, after adding these tags, go to `view > none` and save your notebook to stop the tags from showing automatically when a reader opens the notebook.
 
 For a list of contributors, see the [.bib](https://github.com/qiskit-community/qiskit-textbook/blob/master/content/qiskit-textbook.bib) file.
+
+## Translation Guidelines
+The multi-language translation guideline will be updated later.
+
+### Contributing Guidelines to the Japanese edition of Qiskit Textbook
+#### [日本語翻訳のガイドライン](./i18n/locales/ja/guideline-ja.md)
+#### Contributing New Translations
+- When new content is added to the original textbook, you can contribute to translating it to Japanese by:
+    - Find the corresponding original file under the [`content` folder of the `master` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master/content).
+    - Translate it to Japanese.
+    - Add the translated file under the [`i18n/locales/ja` folder of the `master-ja` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master-ja/i18n/locales/ja) by sending Pull resquest.
+
+#### Contributing Code or a Chapter
+- For contributing code, new section or a chapter to the existing Japanese textbook, please open an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`New Content Suggestion`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=New+Content+Suggestion&template=new-content-suggestion-----.md&title=).
+
+
+For any questions regarding the Japanese edition of the Qiskit Textbook please contact Kifumi Numata (kifumi@jp.ibm.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,16 +47,11 @@ For a list of contributors, see the [.bib](https://github.com/qiskit-community/q
 ## Translation Guidelines
 The multi-language translation guidelines will be updated later.
 
-### Contributing Guidelines to the Japanese edition of Qiskit Textbook
-#### [日本語翻訳のガイドライン](./i18n/locales/ja/guideline-ja.md)
-#### Contributing New Translations
-- When new content is added to the original textbook, you can contribute to translating it to Japanese by:
-    - Find the corresponding original file under the [`content` folder of the `master` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master/content).
-    - Translate it to Japanese.
-    - Add the translated file under the [`i18n/locales/ja` folder of the `master-ja` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master-ja/i18n/locales/ja) by sending Pull resquest.
+### Contributing Guidelines to the [Japanese edition of Qiskit Textbook](https://qiskit.org/textbook/ja/preface.html)
+ [日本語翻訳のガイドライン](./i18n/locales/ja/guideline-ja.md)
 
-#### Contributing Code or a Chapter
-- For contributing code, new section or a chapter to the existing Japanese textbook, please open an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`New Content Suggestion`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=New+Content+Suggestion&template=new-content-suggestion-----.md&title=).
-
-
-For any questions regarding the Japanese edition of the Qiskit Textbook please contact Kifumi Numata (kifumi@jp.ibm.com).
+When new content is added to the original textbook, you can contribute to translating it to Japanese by:
+- Find the corresponding original file under the [`content` folder of the `master` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master/content).
+- Translate it to Japanese.
+- Add the translated file under the [`i18n/locales/ja` folder of the `master-ja` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master-ja/i18n/locales/ja) by sending Pull resquest.
+- For detailed guidelines, please check [here](./i18n/locales/ja/guideline-ja.md).

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Alternatively, you can download the folder [`qiskit-textbook-src`](qiskit-textbo
 
 from the directory that contains this folder.
 
+# Contribution Guidelines
+If you'd like to contribute to Qiskit, please take a look at our [contributors guide](CONTRIBUTING.md).
+
 # License
 The materials and associated source code of this open-source textbook are licensed under [Apache License 2.0](http://github.com/qiskit-community/qiskit-textbook/blob/master/LICENSE.txt).
 
 # Contact
 For any issues, please contact Francis Harkins (francis.harkins@ibm.com) and Abraham Asfaw (abraham.asfaw@ibm.com).
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Alternatively, you can download the folder [`qiskit-textbook-src`](qiskit-textbo
 from the directory that contains this folder.
 
 # Contribution Guidelines
-If you'd like to contribute to Qiskit, please take a look at our [contributors guide](CONTRIBUTING.md).
+If you'd like to contribute to Qiskit Textbook, please take a look at our [contributors guide](CONTRIBUTING.md).
 
 # License
 The materials and associated source code of this open-source textbook are licensed under [Apache License 2.0](http://github.com/qiskit-community/qiskit-textbook/blob/master/LICENSE.txt).

--- a/i18n/locales/ja/guideline-ja.md
+++ b/i18n/locales/ja/guideline-ja.md
@@ -1,0 +1,37 @@
+
+# Contributing Guidelines to the Japanese edition of Qiskit Textbook
+[For English speakers](#contributing-guidelines-to-the-japanese-edition-of-qiskit-textbook-1)
+## [日本語版Qiskitテキストブック](https://qiskit.org/textbook/ja/preface.html)への貢献のためのガイドライン
+### バグの報告と修正・加筆の依頼
+- 問題を見つけたときは、issueテンプレートの[`Content Problem`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=content+bug&template=content-problem---.md&title=)を使って [issue](https://github.com/qiskit-community/qiskit-textbook/issues)を上げてください。
+- Qiskitコミュニティーの目標は、QiskitテクストブックをQiskitを使った量子コンピューティングのベストなテキストブックにすることです。もし補足説明などの追加が必要だと思われる場合は、[`Enhancement Request`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=enhancement&template=enhancement-request---.md&title=)のテンプレートを使って、遠慮なく修正依頼を [issue](https://github.com/qiskit-community/qiskit-textbook/issues)として上げてください。
+
+### コードまたはコンテンツへの貢献
+- 日本語版テキストブックにコードや新しい章やセクションの追加をしたい場合は、[`New Content Suggestion`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=New+Content+Suggestion&template=new-content-suggestion-----.md&title=)のテンプレートを使って [issue](https://github.com/qiskit-community/qiskit-textbook/issues)を上げてください。
+
+### 新コンテンツに対する翻訳
+- 英語版のテキストブックに新しい章が追加された場合、以下の手順で日本語翻訳に貢献いただけます：
+    - [`master` branchの`content`フォルダー](https://github.com/qiskit-community/qiskit-textbook/tree/master/content)に置かれている英語版の該当ファイルを見つけます。
+    - そのファイルを日本語に翻訳します。
+    - [`master-ja` branchの`i18n/locales/ja`フォルダー](https://github.com/qiskit-community/qiskit-textbook/tree/master-ja/i18n/locales/ja) に日本語訳されたファイルを追加するPull requestをしてください。
+
+日本語版のQiskitテキストブックに関するご質問のコンタクト先：沼田祈史 (kifumi@jp.ibm.com) 
+</br>
+</br>
+
+## Contributing Guidelines to the Japanese edition of Qiskit Textbook
+
+### Reporting Bugs and Requesting Enhancements
+- When you encounter a problem, please open an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`Content Problem`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=content+bug&template=content-problem---.md&title=). 
+- The goal of the Qiskit community is to make the Qiskit Textbook the best textbook on quantum computing using Qiskit. If you would like to request an enhancement, please feel free to create an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`Enhancement Request`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=enhancement&template=enhancement-request---.md&title=). 
+
+### Contributing Code or a Chapter
+- For contributing code, new section or a chapter to the existing Japanese textbook, please open an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`New Content Suggestion`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=New+Content+Suggestion&template=new-content-suggestion-----.md&title=).
+
+### Contributing New Translations
+- When new content is added to the original textbook, you can contribute to translating it to Japanese by:
+    - Find the corresponding original file under the [`content` folder of the `master` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master/content).
+    - Translate it to Japanese.
+    - Add the translated file under the [`i18n/locales/ja` folder of the `master-ja` branch](https://github.com/qiskit-community/qiskit-textbook/tree/master-ja/i18n/locales/ja) by sending Pull resquest.
+
+For any questions regarding the Japanese edition of the Qiskit Textbook please contact Kifumi Numata (kifumi@jp.ibm.com).

--- a/i18n/locales/ja/guideline-ja.md
+++ b/i18n/locales/ja/guideline-ja.md
@@ -19,7 +19,7 @@
 </br>
 </br>
 
-## Contributing Guidelines to the Japanese edition of Qiskit Textbook
+## Contributing Guidelines to the [Japanese edition of Qiskit Textbook](https://qiskit.org/textbook/ja/preface.html)
 
 ### Reporting Bugs and Requesting Enhancements
 - When you encounter a problem, please open an [issue](https://github.com/qiskit-community/qiskit-textbook/issues) using the issue template [`Content Problem`](https://github.com/qiskit-community/qiskit-textbook/issues/new?assignees=&labels=content+bug&template=content-problem---.md&title=). 


### PR DESCRIPTION
Resolves [#979 ](https://github.com/qiskit-community/qiskit-textbook/issues/979)

# Changes made
<!--- Please state what you did --->
- Added link to [“ CONTRIBUTING.md”](https://github.com/qiskit-community/qiskit-textbook/blob/master/CONTRIBUTING.md) on README.md.
- Added "Translation Guidelines" chapter and "Contributing Guidelines to the Japanese edition" on  CONTRIBUTING.md.  
- Added new file of "Contributing Guidelines to the Japanese edition" under i18n/locales/ja.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
While we are drafting the guidelines for multi-language translation support, we need the guidelines for updating Japanese edition which has been already released.  This guidelines can help people to contribute the textbook.