### PR TITLE
update position of language selector

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -172,13 +172,15 @@ Textbook numbering starts in Chapter 0.
       {% endunless %}
     {% endfor %}
   </ul>
-  <p class="sidebar_footer">
+  <div class="sidebar_footer">
     <!-- {{ site.sidebar_footer_text }} -->
     
-    <select name="preferred_language" onchange="changeLocale('{{ page.locale }}', this.value)">
-      <option value="en" {% if page.locale == "" || page.locale == "en" %}selected{% endif %}>English</option>
-      <option value="ja" {% if page.locale == "ja" %}selected{% endif %}>Japanese</option>
-    </select>
+    <div class="language_switcher">
+      <select name="preferred_language" onchange="changeLocale('{{ page.locale }}', this.value)">
+        <option value="en" {% if page.locale == "" || page.locale == "en" %}selected{% endif %}>English</option>
+        <option value="ja" {% if page.locale == "ja" %}selected{% endif %}>Japanese</option>
+      </select>
+    </div>
 
-  </p>
+  </div>
 </nav>

--- a/_sass/components/_components.book__layout.scss
+++ b/_sass/components/_components.book__layout.scss
@@ -84,6 +84,10 @@ div.qiskit__navbar {
   @include mq($until: $left-sidebar-width + $spacing-unit-small * 5) {
     width: calc(100vw - #{$spacing-unit-small * 5});
   }
+
+  .c-sidebar__chapters {
+    padding-bottom: 125px;
+  }
 }
 
 .c-sidebar__chapters {

--- a/_sass/components/_components.page__onthispage.scss
+++ b/_sass/components/_components.page__onthispage.scss
@@ -93,7 +93,7 @@ img.textbook_logo {
 }
 
 /* [6] */
-p.sidebar_footer {
+div.sidebar_footer {
   text-align: center;
   padding: 10px 20px 0px 0px;
   font-size: .9em;

--- a/assets/custom/custom.css
+++ b/assets/custom/custom.css
@@ -79,11 +79,15 @@ pre {
 }
 
 p.sidebar_footer {
+	border-right: 1px solid rgba(0, 0, 0, 0.07);
+	border-top: 1px solid rgba(0, 0, 0, 0.07);
+	bottom: 0;
 	direction: ltr;
-	padding: 20px 0 60px 0;
-	position: absolute;
 	left: 0;
-	right: 0;
+	margin: 20px 0 0 0;
+	padding: 0;
+	position: fixed;
+	width: inherit;
 }
 
 .sidebar_footer select {

--- a/assets/custom/custom.css
+++ b/assets/custom/custom.css
@@ -78,9 +78,9 @@ pre {
 	overflow: auto;
 }
 
-p.sidebar_footer {
+div.sidebar_footer {
 	border-right: 1px solid rgba(0, 0, 0, 0.07);
-	border-top: 1px solid rgba(0, 0, 0, 0.07);
+	border-top: 2px solid #8a3ffc;
 	bottom: 0;
 	direction: ltr;
 	left: 0;
@@ -90,11 +90,25 @@ p.sidebar_footer {
 	width: inherit;
 }
 
-.sidebar_footer select {
+.language_switcher::before {
+	background-image: url('/textbook/assets/images/chevron--down.svg');
+	background-size: contain;
+	content: '';
+	display: inline-block;
+	height: 24px;
+	opacity: 0.9;
+	pointer-events: none;
+	position: absolute;
+	right: 24px;
+	top: 14px;
+	width: 24px;
+}
+
+.language_switcher select {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	background-color: #fff;
+	background-color: #F2F4F8;
 	border: 0px none;
 	border-top: 1px solid rgba(0,0,0,0.07);
 	color: #121619;
@@ -106,7 +120,7 @@ p.sidebar_footer {
 	width: 100%;
 }
 
-.sidebar_footer select:hover {
+.language_switcher select:hover {
 	background-color: #DDE1E6;
 }
 

--- a/assets/images/chevron--down.svg
+++ b/assets/images/chevron--down.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<polygon points="16,22 6,12 7.4,10.6 16,19.2 24.6,10.6 26,12 "/>
+<rect id="_x3C_Transparent_Rectangle_x3E_" class="st0" width="32" height="32"/>
+</svg>


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

the language switcher position has been changed to fixed so it always visible as the sidebar scrolls

<img width="610" alt="image" src="https://user-images.githubusercontent.com/13156555/112370596-f86f2400-8cb3-11eb-9bfb-a28869056dc1.png">



# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

Resolves #978 

making the switcher position fixed and always visible ensure users are aware of the ability to change language
