### PR TITLE
Ch 3.2 Fixed math typo

### DIFF
--- a/content/ch-algorithms/deutsch-jozsa.ipynb
+++ b/content/ch-algorithms/deutsch-jozsa.ipynb
@@ -152,7 +152,7 @@
     "   </li>\n",
     "\n",
     "   <li>\n",
-    "       Measure the first register. Notice that the probability of measuring $\\vert 0 \\rangle ^{\\otimes n} = \\lvert \\frac{1}{2^n}\\sum_{x=0}^{2^n-1}(-1)^{f(x)} \\rvert^2$, which evaluates to $1$ if $f(x)$ is constant and $0$ if $f(x)$ is balanced. \n",
+    "       Measure the first register. Notice that the probability of measuring $\\vert 0 \\rangle ^{\\otimes n} = \\lvert \\frac{1}{\\sqrt{2^n}}\\sum_{x=0}^{2^n-1}(-1)^{f(x)} \\rvert^2$, which evaluates to $1$ if $f(x)$ is constant and $0$ if $f(x)$ is balanced. \n",
     "   </li>\n",
     "\n",
     "</ol>\n",
@@ -7709,7 +7709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.2"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

Under section 1.3, the probability of measuring `|0>^n` has its coefficient as `1/2^n` within the modulus squared when it really should be `1/\sqrt{2^n}`.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
For a collection of n qubits, probability of measuring a particular eigenstate is the modulus square of `1/\sqrt{2^n} x <relevant_summation_terms>`.
