### PR TITLE
3.2 Missing amplitudes on Deutsch-Jozsa worked example formula (typo)

### DIFF
--- a/content/ch-algorithms/deutsch-jozsa.ipynb
+++ b/content/ch-algorithms/deutsch-jozsa.ipynb
@@ -238,7 +238,7 @@
     "   <li> Apply Hadamard on the first register\n",
     "        \n",
     "\n",
-    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \\frac{1}{\sqrt{2}} \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
+    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \\frac{1}{\\sqrt{2}} \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
     "\n",
     "\n",
     "   </li>\n",

--- a/content/ch-algorithms/deutsch-jozsa.ipynb
+++ b/content/ch-algorithms/deutsch-jozsa.ipynb
@@ -238,7 +238,7 @@
     "   <li> Apply Hadamard on the first register\n",
     "        \n",
     "\n",
-    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \frac{1}{\sqrt{2}} \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
+    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \\frac{1}{\sqrt{2}} \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
     "\n",
     "\n",
     "   </li>\n",

--- a/content/ch-algorithms/deutsch-jozsa.ipynb
+++ b/content/ch-algorithms/deutsch-jozsa.ipynb
@@ -238,7 +238,7 @@
     "   <li> Apply Hadamard on the first register\n",
     "        \n",
     "\n",
-    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
+    "$$ \\lvert \\psi_3\\rangle = \\lvert 1 \\rangle_{1} \\otimes \\lvert 1 \\rangle_{2} \\otimes \frac{1}{\sqrt{2}} \\left( \\lvert 0 \\rangle - \\lvert 1 \\rangle \\right)_{3} $$\n",
     "\n",
     "\n",
     "   </li>\n",


### PR DESCRIPTION
If I'm not mistaken on chapter 3.2  (Deutsch-Jozsa Algorithm) section 2 (Worked example) step 5 is missing amplitudes on qubit 3.

# Changes made
Added amplitude 1/sqrt(2)

# Justification
Qubit 3 is not affected by the last step of the circuit, so it maintains the |-> state, needing the 1/sqrt(2) to give equal probability to be in state |0> or |1>
