### PR TITLE
change icon for linking to github

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -60,7 +60,7 @@
 	class="download__link"
       >
       {{ messages.contribute_github }}
-      <img src="{{ site.images_url | relative_url }}/rightarrow_purple.svg" class="download-button">
+      <img src="{{ site.images_url | relative_url }}/launch.svg" class="download-button">
       </a>
     </div>
     {% endunless %}

--- a/assets/images/launch.svg
+++ b/assets/images/launch.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="launch.svg"
+   version="1.1"
+   viewBox="0 0 32 32"
+   height="32"
+   width="32"
+   id="icon">
+  <metadata
+     id="metadata845">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:current-layer="icon"
+     inkscape:window-maximized="0"
+     inkscape:window-y="37"
+     inkscape:window-x="190"
+     inkscape:cy="16"
+     inkscape:cx="16"
+     inkscape:zoom="21"
+     showgrid="false"
+     id="namedview843"
+     inkscape:window-height="1007"
+     inkscape:window-width="1302"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     inkscape:document-rotation="0"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs835">
+    <style
+       id="style833">
+      .cls-1 {
+        fill: none;
+      }
+    </style>
+  </defs>
+  <path
+     style="stroke:none;stroke-opacity:1;fill:#6929c4;fill-opacity:1"
+     id="path837"
+     d="M26,28H6a2.0027,2.0027,0,0,1-2-2V6A2.0027,2.0027,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0027,2.0027,0,0,1,26,28Z" />
+  <polygon
+     style="fill:#6929c4;fill-opacity:1"
+     id="polygon839"
+     points="20 2 20 4 26.586 4 18 12.586 19.414 14 28 5.414 28 12 30 12 30 2 20 2" />
+  <rect
+     height="32"
+     width="32"
+     class="cls-1"
+     data-name="&lt;Transparent Rectangle&gt;"
+     id="_Transparent_Rectangle_" />
+</svg>


### PR DESCRIPTION
# Changes made
Link should use the "launch" icon instead of the rightarrow

# Justification
To be consistent with design throughout qiskit.org
