### PR TITLE
3.12 fixed some grammatical mistakes in 3.12 Quantum Key Distribution

### DIFF
--- a/content/ch-algorithms/quantum-key-distribution.ipynb
+++ b/content/ch-algorithms/quantum-key-distribution.ipynb
@@ -34,11 +34,11 @@
    "source": [
     "## 1. Introduction\n",
     "\n",
-    "When Alice and Bob want to communicate a secret message (such as Bob’s online banking details) over an insecure channel (such as the internet), its essential to encrypt the message. Since cryptography is a large area and almost all of it is outside the scope of this textbook, we will have to believe that Alice and Bob having a secret key that no-one else knows is useful and allows them to communicate using symmetric-key cryptography.\n",
+    "When Alice and Bob want to communicate a secret message (such as Bob’s online banking details) over an insecure channel (such as the internet), it is essential to encrypt the message. Since cryptography is a large area and almost all of it is outside the scope of this textbook, we will have to believe that Alice and Bob having a secret key that no one else knows is useful and allows them to communicate using symmetric-key cryptography.\n",
     "\n",
     "If Alice and Bob want to use Eve’s classical communication channel to share their key, it is impossible to tell if Eve has made a copy of this key for herself- they must place complete trust in Eve that she is not listening. If, however, Eve provides a quantum communication channel, Alice and Bob no longer need to trust Eve at all- they will know if she tries to read Bob’s message before it gets to Alice.\n",
     "\n",
-    "For some readers, it may be useful to give an idea of how a quantum channel may be physically implemented. An example of a classical channel could be a telephone line; we send electric signals through the line that represent our message (or bits). A proposed example of a quantum communication channel could be some kind of fibre-optic cable, through which we can send individual photons (particles of light). Photons have a property call _polarisation,_ and this polarisation can be one of two states. We can use this to represent a qubit.\n",
+    "For some readers, it may be useful to give an idea of how a quantum channel may be physically implemented. An example of a classical channel could be a telephone line; we send electric signals through the line that represent our message (or bits). A proposed example of a quantum communication channel could be some kind of fibre-optic cable, through which we can send individual photons (particles of light). Photons have a property called _polarisation,_ and this polarisation can be one of two states. We can use this to represent a qubit.\n",
     "\n",
     "\n",
     "## 2. Protocol Overview  \n",
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If Alice prepares a qubit in the state $|+\\rangle$ (`0` in the X-basis), and Bob measures it in the X-basis, Bob is sure to measure `0`:"
+    "If Alice prepares a qubit in the state $|+\\rangle$ (`0` in the $X$-basis), and Bob measures it in the $X$-basis, Bob is sure to measure `0`:"
    ]
   },
   {
@@ -906,7 +906,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But if Eve tries to measure this qubit in the Z-basis before it reaches Bob, she will change the qubit's state from $|+\\rangle$ to either $|0\\rangle$ or $|1\\rangle$, and Bob is no longer certain to measure `0`:"
+    "But if Eve tries to measure this qubit in the $Z$-basis before it reaches Bob, she will change the qubit's state from $|+\\rangle$ to either $|0\\rangle$ or $|1\\rangle$, and Bob is no longer certain to measure `0`:"
    ]
   },
   {
@@ -1925,7 +1925,7 @@
     "\n",
     "**- Step 2**\n",
     "\n",
-    "Alice then encodes each bit onto a string of qubits using the basis she chose, this means each qubit is in one of the states $|0\\rangle$, $|1\\rangle$, $|+\\rangle$ or $|-\\rangle$, chosen at random. In this case, the string of qubits would look like this:\n",
+    "Alice then encodes each bit onto a string of qubits using the basis she chose; this means each qubit is in one of the states $|0\\rangle$, $|1\\rangle$, $|+\\rangle$ or $|-\\rangle$, chosen at random. In this case, the string of qubits would look like this:\n",
     "\n",
     "$$ |1\\rangle|0\\rangle|+\\rangle|0\\rangle|-\\rangle|+\\rangle|-\\rangle|0\\rangle|-\\rangle|1\\rangle|+\\rangle|-\\rangle|+\\rangle|-\\rangle|+\\rangle|+\\rangle\n",
     "$$\n",
@@ -1955,7 +1955,7 @@
    "source": [
     "## 3. Qiskit Example: Without Interception\n",
     "\n",
-    "Let’s first see how the protocol works when no-one is listening in, then we can see how Alice and Bob are able to detect an eavesdropper. As always, let's start by importing everything we need:"
+    "Let’s first see how the protocol works when no one is listening in, then we can see how Alice and Bob are able to detect an eavesdropper. As always, let's start by importing everything we need:"
    ]
   },
   {
@@ -2598,7 +2598,7 @@
     "|      message      |     message      |     message     |\n",
     "|                   |                  |    bob_bases    |\n",
     "\n",
-    "Below, the function `measure_message`, applies the corresponding measurement and simulates the result of measuring each qubit. We store the measurement results in `bob_results`."
+    "Below, the function `measure_message` applies the corresponding measurement and simulates the result of measuring each qubit. We store the measurement results in `bob_results`."
    ]
   },
   {
@@ -4668,7 +4668,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Made some changes in documentation/text for fixing grammatical mistakes and for consistency. For eg:

- its essential -> it is essential
- no-one -> no one (see the recommended usage at [Grammarly](https://www.grammarly.com/blog/no-one-noone/) )
- X-basis -> $X$-basis for consistent notation
- Other minor changes

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

- The changes are intended to correct grammatical mistakes and maintain consistency (for e.g. in existing version, X-basis is written in text as X-basis as well as $X$-basis. This has been changed to $X$ everywhere). There are no technical/code changes.