### PR TITLE
[CHSH] correct cell tag

### DIFF
--- a/content/ch-demos/chsh.ipynb
+++ b/content/ch-demos/chsh.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {
     "tags": [
-     "remove-cell"
+     "remove_cell"
     ]
    },
    "source": [


### PR DESCRIPTION
# Changes made
- Fixed a cell tag

# Justification
- Cell tag was not the keyword needed to remove the title on the website (and avoid duplicate titles)
- I think this needed to happen in a separate PR to avoid destroying author history