### PR TITLE
2.2 Fixed inconsistent scaling in Dirac notation

### DIFF
--- a/content/ch-gates/proving-universality.ipynb
+++ b/content/ch-gates/proving-universality.ipynb
@@ -83,7 +83,7 @@
     "Another consequence of unitarity is that it preserves the inner product between two arbitrary states. Specifically, take two states $\\left| \\psi_0 \\right\\rangle$ and $\\left| \\psi_1 \\right\\rangle$. The inner product of these is $\\left\\langle \\psi_0 | \\psi_1 \\right\\rangle$. If we apply the same unitary $U$ to both, the inner product of the resulting states is exactly the same,\n",
     "\n",
     "$$\n",
-    "\\left( \\left\\langle \\psi_0 \\right| U^\\dagger \\right) \\left( U \\left| \\psi_1 \\right\\rangle \\right) = \\left\\langle \\psi_0 |U^\\dagger U| \\psi_1 \\right\\rangle = \\left\\langle \\psi_0 | \\psi_1 \\right\\rangle.\n",
+    "\\left( \\left\\langle \\psi_0 \\right| U^\\dagger \\right) \\left( U \\left| \\psi_1 \\right\\rangle \\right) = \\left\\langle \\psi_0 \\right|U^\\dagger U\\left| \\psi_1 \\right\\rangle = \\left\\langle \\psi_0 | \\psi_1 \\right\\rangle.\n",
     "$$\n",
     "\n",
     "This property provides us with a useful way of thinking about these gates. It means that for any set of states $\\{ \\left| \\psi_j \\right\\rangle \\}$ that provide an orthonormal basis for our system, the set of states $\\{ \\left| \\phi_j \\right\\rangle = U \\left| \\psi_j \\right\\rangle \\}$ will also be an orthonormal basis. The unitary can then be thought of as a rotation between these bases, and can be written accordingly as\n",


### PR DESCRIPTION
An expression in section 2.2 looks like:
$\left\langle \psi_0 |U^\dagger U| \psi_1 \right\rangle$

Whereas it should look like:
$\left\langle \psi_0 \right|U^\dagger U\left| \psi_1 \right\rangle$

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
Added \left and \right where they were missing.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The expression is much easier to read if $\left\langle \psi_0 \right|$ looks like one item, and $\left| \psi_1 \right\rangle$ looks like one item.