### PR TITLE
2.3 Fix typo introduced in previous commit ccc3ff4

### DIFF
--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -41319,7 +41319,7 @@
     "<br>\n",
     "<img src=\"images/pkb_ex1.svg\">\n",
     "</li>\n",
-    "<li>What would happen to the control qubit (q0) if the if the target qubit (q1) was in the state $|1\\rangle$, and the circuit used a controlled-Sdg gate instead of the controlled-T (as shown in the circuit below)?\n",
+    "<li>What would happen to the control qubit (q0) if the target qubit (q1) was in the state $|1\\rangle$, and the circuit used a controlled-Sdg gate instead of the controlled-T (as shown in the circuit below)?\n",
     "<br>\n",
     "<img src=\"images/pkb_ex2.svg\">\n",
     "</li>\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Removed extra "if the" from quick exercise question.
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

![image](https://user-images.githubusercontent.com/9458918/116789241-81158700-aae0-11eb-9903-28c272b4a3b6.png)

Its a typo.