### PR TITLE
Fixed Grammar Errors

### DIFF
--- a/content/ch-quantum-hardware/calibrating-qubits-pulse.ipynb
+++ b/content/ch-quantum-hardware/calibrating-qubits-pulse.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "Qiskit Pulse provides a language for specifying pulse level control (i.e. control of the continuous time dynamics of input signals) of a general quantum device independent of the specific hardware implementation (Ref. [2](#refs)). \n",
     "\n",
-    "In this tutorial, we show how to implement typical single-qubit calibration and characterization experiments using Qiskit and Qiskit Pulse. These are typically the first round of experiments that would be done in the lab immediately after a device has been fabricated and installed into a system. The presentation is pedagogical, and allows students to explore two-level-system dynamics experimentally. All units are returned as standard SI (ie Hz, sec, etc).\n",
+    "In this tutorial, we show how to implement typical single-qubit calibration and characterization experiments using Qiskit and Qiskit Pulse. These are typically the first round of experiments that would be done in the lab immediately after a device has been fabricated and installed into a system. The presentation is pedagogical, and allows students to explore two-level-system dynamics experimentally. All units are returned as standard SI (i.e., Hz, sec, etc.).\n",
     "\n",
     "Each experiment gives us more information about the system, which is typically used in subsequent experiments. For this reason, this notebook has to be mostly executed in order."
    ]
@@ -202,7 +202,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "# unit conversion factors -> all backend properties returned in SI (Hz, sec, etc)\n",
+    "# unit conversion factors -> all backend properties returned in SI (Hz, sec, etc.)\n",
     "GHz = 1.0e9 # Gigahertz\n",
     "MHz = 1.0e6 # Megahertz\n",
     "us = 1.0e-6 # Microseconds\n",


### PR DESCRIPTION
6.1 Calibrating Qubits with Qiskit Pulse

# Changes made
Corrected the usage of i.e. and etc.

# Justification
In the following lines, the usage of i.e. and etc. are not grammatically correct. 
"All units are returned as standard SI (ie Hz, sec, etc)."
"all backend properties returned in SI (Hz, sec, etc)"

I have replaced ie with 'i.e.,' and etc with 'etc.' in the above sentences.
