### PR TITLE
6.2 Accessing Higher Energy States: Fixing the typos

### DIFF
--- a/content/ch-quantum-hardware/accessing_higher_energy_states.ipynb
+++ b/content/ch-quantum-hardware/accessing_higher_energy_states.ipynb
@@ -148,7 +148,7 @@
     "\n",
     "backend_defaults = backend.defaults()\n",
     "\n",
-    "# unit conversion factors -> all backend properties returned in SI (Hz, sec, etc)\n",
+    "# unit conversion factors -> all backend properties returned in SI (Hz, sec, etc.)\n",
     "GHz = 1.0e9 # Gigahertz\n",
     "MHz = 1.0e6 # Megahertz\n",
     "us = 1.0e-6 # Microseconds\n",
@@ -1206,7 +1206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have calibrated the $0, 1$ discriminator, we move on to exciting higher energy states. Specifically, we focus on exciting the $|2\\rangle$ state and building a discriminator to classify $|0\\rangle$, $|1\\rangle$ and $2\\rangle$ states from their respective IQ data points. The procedure for even higher states ($|3\\rangle$, $|4\\rangle$, etc) should be similar, but we have not tested them explicitly."
+    "Now that we have calibrated the $0, 1$ discriminator, we move on to exciting higher energy states. Specifically, we focus on exciting the $|2\\rangle$ state and building a discriminator to classify $|0\\rangle$, $|1\\rangle$ and $2\\rangle$ states from their respective IQ data points. The procedure for even higher states ($|3\\rangle$, $|4\\rangle$, etc.) should be similar, but we have not tested them explicitly."
    ]
   },
   {
@@ -1544,7 +1544,7 @@
     ]
    },
    "source": [
-    "We now use the estimate obtained above to do a refined sweep (ie much smaller range). This will allow us to obtain a more accurate value for the $1\\rightarrow2$ frequency. We sweep $20$ MHz in each direction."
+    "We now use the estimate obtained above to do a refined sweep (i.e., much smaller range). This will allow us to obtain a more accurate value for the $1\\rightarrow2$ frequency. We sweep $20$ MHz in each direction."
    ]
   },
   {
@@ -2162,7 +2162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now observe a third centroid corresponding to the $|2\\rangle$ state. (Note: If the plot looks off, rerun the notebook)"
+    "We now observe a third centroid corresponding to the $|2\\rangle$ state. (Note: If the plot looks off, rerun the notebook.)"
    ]
   },
   {


### PR DESCRIPTION
# Changes made
I have replaced 'ie' with 'i.e.,' and 'etc' with 'etc.'. 

A fullstop is missing in the following sentence, which I have added.
"(Note: If the plot looks off, rerun the notebook)"

# Justification
The replaced forms of 'ie' and 'etc' follow the correct usage.