### PR TITLE
6.5 Exploring the Jaynes-Cummings Hamiltonian with Qiskit Pulse: Fixing the typos

### DIFF
--- a/content/ch-quantum-hardware/Jaynes-Cummings-model.ipynb
+++ b/content/ch-quantum-hardware/Jaynes-Cummings-model.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "### Physics Background\n",
     "\n",
-    "The Jaynes-Cummings model describes a two-level system (qubit) interacting with a single-mode of an electromagnetic cavity (resonator). When a two-level system is placed in a cavity, it couples to the cavity with strength $g$, spontaneously emits its excitation with rate $\\gamma$, while the cavity decays with rate $\\kappa$. In this tutorial we measure the parameters of a system consting of a superconducting qubit coupled to a superconducting resonator using Qiskit Pulse."
+    "The Jaynes-Cummings model describes a two-level system (qubit) interacting with a single-mode of an electromagnetic cavity (resonator). When a two-level system is placed in a cavity, it couples to the cavity with strength $g$, spontaneously emits its excitation with rate $\\gamma$, while the cavity decays with rate $\\kappa$. In this tutorial we measure the parameters of a system consisting of a superconducting qubit coupled to a superconducting resonator using Qiskit Pulse."
    ]
   },
   {
@@ -26,15 +26,15 @@
     "\n",
     "$H_{JC}/\\hbar=\\omega_r(a^\\dagger a) - \\frac{1}{2} \\omega_q \\sigma_z + g (\\sigma_+ a + \\sigma_- a^\\dagger)$\n",
     "\n",
-    "Let's break down this Hamiltonian in different parts: The first part of the Hamiltonian $H_r/\\hbar=\\omega_r(a^\\dagger a)$ describes the resonator. The resonator can be treated as a quantum harmonic oscillator, where $\\omega_r$ is the resonator frequency, and $a$ and $a^\\dagger$ are the raising a lowering operators of the resonator photons. Note that for simplicity we have omitted the zero point enegery of the harmonic oscillator. The next term in the JC Hamiltoninan $H_q/\\hbar=-\\frac{1}{2} \\omega_q \\sigma_z$ describes the qubit. Here, $\\omega_q$ is the qubit frequency, and $\\sigma_z$ is the Pauli-Z operator. The final term of the Hamiltonian $H_{rq}/\\hbar=g (\\sigma_+ a + \\sigma_- a^\\dagger)$ describes the interaction between the resonator and the qubit: $g$ is the coupling strength between the qubit and the resonator, and the operators $\\sigma_+$ and $\\sigma_-$ represent exciting and de-exciting the qubit. Based on this interaction term we can see that the process of exciting a qubit leads to a photon loss in the resonator and vice-versa. \n",
+    "Let's break down this Hamiltonian in different parts: The first part of the Hamiltonian $H_r/\\hbar=\\omega_r(a^\\dagger a)$ describes the resonator. The resonator can be treated as a quantum harmonic oscillator, where $\\omega_r$ is the resonator frequency, and $a$ and $a^\\dagger$ are the raising a lowering operators of the resonator photons. Note that for simplicity we have omitted the zero point energy of the harmonic oscillator. The next term in the JC Hamiltonian $H_q/\\hbar=-\\frac{1}{2} \\omega_q \\sigma_z$ describes the qubit. Here, $\\omega_q$ is the qubit frequency, and $\\sigma_z$ is the Pauli-Z operator. The final term of the Hamiltonian $H_{rq}/\\hbar=g (\\sigma_+ a + \\sigma_- a^\\dagger)$ describes the interaction between the resonator and the qubit: $g$ is the coupling strength between the qubit and the resonator, and the operators $\\sigma_+$ and $\\sigma_-$ represent exciting and de-exciting the qubit. Based on this interaction term we can see that the process of exciting a qubit leads to a photon loss in the resonator and vice-versa. \n",
     "\n",
     "In the limit that detuning between the qubit and the resonator $\\Delta=\\omega_q-\\omega_r$ is less than the coupling strength between the two, $|\\Delta|\\ll g$, the resonator-qubit system becomes hybridized, leading to coherent excitation swaps which can be useful for certain two-qubit operations. However, for optimal readout, we want to operate the system in the dispersive limit, where the qubit-resonator detuning is much larger than the coupling rate and the resonator decay rate: $|\\Delta| \\gg g,\\kappa$. In this limit the interaction between the qubit and resonator influences each of their frequencies, a feature that can be used for measuring the state of the qubit. We can apply the dispersive approximation in the limit of few photons in the resonator, and approximate the JC Hamiltonian using second-order perturbation theory as: \n",
     "\n",
     "$H_{JC(disp)}/\\hbar=(\\omega_r+ \\chi \\sigma_z) a^\\dagger a + \\frac{1}{2} \\tilde{\\omega}_q \\sigma_z$\n",
     "\n",
-    "where $\\chi=-g^2/\\Delta$ is the dispersive shift (the negative sign is ue to the fact that the transmon has a negative anharmonicity), and $\\tilde{\\omega}_q= \\omega_q+g^2/\\Delta$ is the modified qubit frequency, experiencing a Lamb shift.\n",
+    "where $\\chi=-g^2/\\Delta$ is the dispersive shift (the negative sign is due to the fact that the transmon has a negative anharmonicity), and $\\tilde{\\omega}_q= \\omega_q+g^2/\\Delta$ is the modified qubit frequency, experiencing a Lamb shift.\n",
     "\n",
-    "The circuit quantum electrodynamics derivations are disscussed in another <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a>. "
+    "The circuit quantum electrodynamics derivations are discussed in another <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a>. "
    ]
   },
   {
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then extract the default backend configuration and settings for the selected chip"
+    "We then extract the default backend configuration and settings for the selected chip."
    ]
   },
   {
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we define some helper functions that we will use for fitting and interpreting our data"
+    "Next we define some helper functions that we will use for fitting and interpreting our data."
    ]
   },
   {
@@ -277,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we send our pulse sequence to the hardware"
+    "Here we send our pulse sequence to the hardware."
    ]
   },
   {
@@ -449,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we send our pulse sequence to the hardware"
+    "Here we send our pulse sequence to the hardware."
    ]
   },
   {
@@ -495,7 +495,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And then we access the measurement data for the high power resonator spectroscopy scan"
+    "And then we access the measurement data for the high power resonator spectroscopy scan."
    ]
   },
   {
@@ -522,7 +522,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally we plot the high power resonator spectroscopy next to the low power scan from the previous section and use the shift in resonator frequency to calculate $\\chi$"
+    "Finally we plot the high power resonator spectroscopy next to the low power scan from the previous section and use the shift in resonator frequency to calculate $\\chi$."
    ]
   },
   {
@@ -593,7 +593,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A qubit coupled to a resonator will spontaneous emit photons into the cavity, and therefore relaxing from an excited state to the ground state. The spontaneous emission of photons gets enhanced by the qubit environment, a phenomenon known as the Purcell effect. We can measure the qubit decay rate $\\gamma$ by exciting the qubit with a microwave drive, and measuring the decay rate $T_1=1/\\gamma$ of the qubit excitation. This experiment is a common method method for measuring qubit coherence properties as discussed in this <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a>. For this experiment our microwave drive doesn't have to be $\\pi$-pulse "
+    "A qubit coupled to a resonator will spontaneous emit photons into the cavity, and therefore relaxing from an excited state to the ground state. The spontaneous emission of photons gets enhanced by the qubit environment, a phenomenon known as the Purcell effect. We can measure the qubit decay rate $\\gamma$ by exciting the qubit with a microwave drive, and measuring the decay rate $T_1=1/\\gamma$ of the qubit excitation. This experiment is a common method method for measuring qubit coherence properties as discussed in this <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a>. For this experiment our microwave drive doesn't have to be $\\pi$-pulse."
    ]
   },
   {
@@ -665,7 +665,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we send our pulse sequence to the hardware"
+    "Here we send our pulse sequence to the hardware."
    ]
   },
   {
@@ -777,7 +777,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this chapter we introduce the Jaynes-Cummings model and we consider the relevant quantities for a system consisting of a qubit coupled to a cavity. We use Qiskit Pulse to extract the qubit-resonator coupling strength $g$, the qubit spontaneous emission rate $\\gamma$, and the cavity decay rate $\\kappa$. These parameters combined with the qubit frequency and the resonator frequency that we measured in a previous <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a> allow us to describe our qubit-resonator system."
+    "In this chapter, we introduce the Jaynes-Cummings model and we consider the relevant quantities for a system consisting of a qubit coupled to a cavity. We use Qiskit Pulse to extract the qubit-resonator coupling strength $g$, the qubit spontaneous emission rate $\\gamma$, and the cavity decay rate $\\kappa$. These parameters combined with the qubit frequency and the resonator frequency that we measured in a previous <a href=\"https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html\">chapter</a> allow us to describe our qubit-resonator system."
    ]
   },
   {


### PR DESCRIPTION
# Changes made

1. Corrected the following spelling errors:
consting -> consisting
enegery -> energy
Hamintoninan -> Hamintonian
ue to -> due to
disscussed -> discussed

2. Added full stops at the end of several sentences. Some examples are:
"Next we define some helper functions that we will use for fitting and interpreting our data"
"Here we send our pulse sequence to the hardware"
"And then we access the measurement data for the high power resonator spectroscopy scan"
"Finally we plot the high power resonator spectroscopy next to the low power scan from the previous section and use the shift in resonator frequency to calculate χ"
"For this experiment our microwave drive doesn't have to be π-pulse"

3. Added a comma after chapter in the following sentence:
"In this chapter we introduce the Jaynes-Cummings model and we consider the relevant quantities for a system consisting of a qubit coupled to a cavity."

# Justification
None, as the changes made are self-explanatory.