### PR TITLE
6.6 Measuring the Qubit ac-Stark Shift: Added missing commas and full stops

### DIFF
--- a/content/ch-quantum-hardware/ac-Stark-shift.ipynb
+++ b/content/ch-quantum-hardware/ac-Stark-shift.ipynb
@@ -12,11 +12,11 @@
     "\n",
     "$H_{JC(disp)}/\\hbar=\\omega_r (a^\\dagger a+\\frac{1}{2}) + \\frac{1}{2} (\\omega_q + \\frac{g^2}{\\Delta} + \\frac{2g^2}{\\Delta} a^\\dagger a) \\sigma_z$\n",
     "\n",
-    "where $a$ and $a^\\dagger$ are the raising a lowering operators of the resonator photons, and $\\sigma_z$ is the Pauli-Z operator acting on the qubit. In this frame the qubit frequency \n",
+    "where $a$ and $a^\\dagger$ are the raising a lowering operators of the resonator photons, and $\\sigma_z$ is the Pauli-Z operator acting on the qubit. In this frame, the qubit frequency \n",
     "\n",
     "$\\tilde{\\omega}_q=\\omega_q + \\frac{g^2}{\\Delta} + \\frac{2g^2}{\\Delta} \\bar{n}$ \n",
     "\n",
-    "experiences a constant Lamb shift of $g^2/\\Delta$ induced by the vacuum fluctuations in the resonator, and an ac-Stark shift of $(2g^2/\\Delta) \\bar{n}$ where $\\bar{n}=\\langle a^\\dagger a \\rangle$ is the average number of photons present in the resonator. For more details checkout this <a href=\"https://arxiv.org/abs/cond-mat/0408367\">paper</a>. In this tutorial we investigate the ac-Stark shift of the qubit caused by the photon population in the resonator using Qiskit Pulse."
+    "experiences a constant Lamb shift of $g^2/\\Delta$ induced by the vacuum fluctuations in the resonator, and an ac-Stark shift of $(2g^2/\\Delta) \\bar{n}$ where $\\bar{n}=\\langle a^\\dagger a \\rangle$ is the average number of photons present in the resonator. For more details checkout this <a href=\"https://arxiv.org/abs/cond-mat/0408367\">paper</a>. In this tutorial, we investigate the ac-Stark shift of the qubit caused by the photon population in the resonator using Qiskit Pulse."
    ]
   },
   {
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll first get our basic dependencies set up and ready to go."
+    "We'll first set up our basic dependencies so we're ready to go."
    ]
   },
   {
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then extract the default backend configuration and settings for the selected chip"
+    "We then extract the default backend configuration and settings for the selected chip."
    ]
   },
   {
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we define some helper functions that we will use for fitting and interpreting our data"
+    "Next, we define some helper functions that we will use for fitting and interpreting our data."
    ]
   },
   {
@@ -142,7 +142,7 @@
    "metadata": {},
    "source": [
     "### 1.  ac-Stark Shifting the qubit\n",
-    "In order to ac-Stark shift the qubit we need to populate the resonator with photons using an on-resonance drive. For a drive amplitude $\\epsilon$, and a resonator decay rate of $\\kappa$, the number of photons in the resonator $\\bar{n}=\\langle a^\\dagger a \\rangle = \\frac{\\epsilon^2}{\\Delta^2 +(\\kappa/2)^2}$. As a reminder $\\tilde{\\omega}_q=\\omega_q + \\frac{g^2}{\\Delta} + \\delta \\omega_q$ where the shift in frequency due to ac_Stark shift is $\\delta \\omega_q = \\frac{2g^2}{\\Delta} \\bar{n}$. Since $\\Delta=\\omega_q-\\omega_r<0$ the qubit frequency gets smaller as we increase the of photons in the resonator"
+    "In order to ac-Stark shift the qubit we need to populate the resonator with photons using an on-resonance drive. For a drive amplitude $\\epsilon$, and a resonator decay rate of $\\kappa$, the number of photons in the resonator $\\bar{n}=\\langle a^\\dagger a \\rangle = \\frac{\\epsilon^2}{\\Delta^2 +(\\kappa/2)^2}$. As a reminder $\\tilde{\\omega}_q=\\omega_q + \\frac{g^2}{\\Delta} + \\delta \\omega_q$ where the shift in frequency due to ac-Stark shift is $\\delta \\omega_q = \\frac{2g^2}{\\Delta} \\bar{n}$. Since $\\Delta=\\omega_q-\\omega_r<0$ the qubit frequency gets smaller as we increase the of photons in the resonator."
    ]
   },
   {
@@ -255,7 +255,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we send our pulse sequence to the hardware"
+    "Here, we send our pulse sequence to the hardware."
    ]
   },
   {
@@ -372,7 +372,7 @@
    "metadata": {},
    "source": [
     "### 2.  Qubit frequency shift and linewidth broadening\n",
-    "Using the Jaynes-Cummings model we expect a qubit frequency shift of $\\delta \\omega_q = \\frac{2g^2}{\\Delta} \\bar{n}$. The qubit frequency experiences fluctuations due the photon shot-noise which leads to qubit linewidth broadening and a dephasing rate of $\\Gamma_\\phi=\\frac{4 \\chi^2}{\\kappa} \\bar{n}$"
+    "Using the Jaynes-Cummings model we expect a qubit frequency shift of $\\delta \\omega_q = \\frac{2g^2}{\\Delta} \\bar{n}$. The qubit frequency experiences fluctuations due the photon shot-noise which leads to qubit linewidth broadening and a dephasing rate of $\\Gamma_\\phi=\\frac{4 \\chi^2}{\\kappa} \\bar{n}$."
    ]
   },
   {
@@ -443,7 +443,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this chapter we discuss the ac-Stark shift that the qubit experiences due to the presence of photons in the resonator. We use Qiskit Pulse to measure the qubit frequency shift and linewidth broadening"
+    "In this chapter, we discuss the ac-Stark shift that the qubit experiences due to the presence of photons in the resonator. We use Qiskit Pulse to measure the qubit frequency shift and linewidth broadening."
    ]
   },
   {


### PR DESCRIPTION
6.6 Measuring the Qubit ac-Stark Shift

# Changes made
1. Added missing commas and full stops in several sentences. For example, 'Next we define some helper functions that we will use for fitting and interpreting our data' was changed to 'Next, we define some helper functions that we will use for fitting and interpreting our data.'

2. Replaced 'ac_Stark' with 'ac-Stark' in section '1. ac-Stark Shifting the qubit'.

# Justification
I made the changes to improve readability.