### PR TITLE
6.7 Hamiltonian Tomography: Fixing spelling errors

### DIFF
--- a/content/ch-quantum-hardware/hamiltonian-tomography.ipynb
+++ b/content/ch-quantum-hardware/hamiltonian-tomography.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "## Introduction <a class=\"anchor\" id=\"introduction\"></a>\n",
     "\n",
-    "The cross resonance gate for entangling qubits was introducted in [this section](https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html#6.-The-Cross-Resonance-Entangling-Gate-) of the Qiskit Textbook, where it is assumed the transmon is a qubit and the Schrieffer-Wolff transformation is applied to yield an effective Hamiltonian \n",
+    "The cross resonance gate for entangling qubits was introduced in [this section](https://qiskit.org/textbook/ch-quantum-hardware/cQED-JC-SW.html#6.-The-Cross-Resonance-Entangling-Gate-) of the Qiskit Textbook, where it is assumed the transmon is a qubit and the Schrieffer-Wolff transformation is applied to yield an effective Hamiltonian \n",
     "\n",
     "$$\n",
     "\\tilde{H}_{\\rm eff}^{\\rm CR} = - \\frac{\\Delta_{12}}{2}\\sigma_1^z \n",
@@ -43,18 +43,18 @@
     "a_{x} \\hat{Z}\\hat{X} + a_{y} \\hat{Z}\\hat{Y} + a_{z} \\hat{Z}\\hat{Z} + b_{x}  \\hat{I}\\hat{X} + b_{y} \\hat{I}\\hat{Y} + b_{z} \\hat{I}\\hat{Z}  \n",
     "$$\n",
     "\n",
-    "where we will omit the Kronecker product symbol $\\otimes$ for succinctness.  We refer to the first Pauli operator acting on the control qubit and second operators acting on the target qubits, as in the effective Hamiltonian above.  While the form of the cross resonance Hamiltonian is known, the individual coeficients $a_{\\mu}, b_{\\nu}$ are not known. Note that these coefficients are also referred to as the strengths of the interaction they correspond to, i.e. $a_x$ is the $ZX$ interaction rate, etc. We must then find a way of extracting the coefficients from measurements made on the system after the cross resonance pulse is applied for different durations. Before we proceed, it should be noted that cross resonance operation also generates a $\\hat{Z}\\hat{I}$ interaction arising from a Stark shift (off-resonant drive that dressed the qubit frequency). This term can be extracted by preforming a [Ramsey experiment](https://qiskit.org/textbook/ch-quantum-hardware/calibrating-qubits-pulse.html#4.1-Measuring-the-qubit-Frequency-Precisely-using-a-Ramsey-Experiment-) on the control qubit. We will discuss this Ramsey procedure later on, so for know let us focus on the Hamiltonian that we wrote down.\n",
+    "where we will omit the Kronecker product symbol $\\otimes$ for succinctness.  We refer to the first Pauli operator acting on the control qubit and second operators acting on the target qubits, as in the effective Hamiltonian above.  While the form of the cross resonance Hamiltonian is known, the individual coefficients $a_{\\mu}, b_{\\nu}$ are not known. Note that these coefficients are also referred to as the strengths of the interaction they correspond to, i.e. $a_x$ is the $ZX$ interaction rate, etc. We must then find a way of extracting the coefficients from measurements made on the system after the cross resonance pulse is applied for different durations. Before we proceed, it should be noted that cross resonance operation also generates a $\\hat{Z}\\hat{I}$ interaction arising from a Stark shift (off-resonant drive that dressed the qubit frequency). This term can be extracted by preforming a [Ramsey experiment](https://qiskit.org/textbook/ch-quantum-hardware/calibrating-qubits-pulse.html#4.1-Measuring-the-qubit-Frequency-Precisely-using-a-Ramsey-Experiment-) on the control qubit. We will discuss this Ramsey procedure later on, so for know let us focus on the Hamiltonian that we wrote down.\n",
     "\n",
-    "The coefficients $a_{\\mu}, b_{\\nu}$ (interaction rates) will be extracted by taking six different measurements as a function of the duration of the pulse.  The six measurments are of the expectation value of each Pauli term on the target qubit with the control qubit either in the ground or excited state. In the next section we will show how these measurments give us information about the coefficients."
+    "The coefficients $a_{\\mu}, b_{\\nu}$ (interaction rates) will be extracted by taking six different measurements as a function of the duration of the pulse.  The six measurements are of the expectation value of each Pauli term on the target qubit with the control qubit either in the ground or excited state. In the next section we will show how these measurements give us information about the coefficients."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fitting Fuctions <a class=\"anchor\" id=\"fitting-functions\"></a>\n",
+    "## Fitting Functions <a class=\"anchor\" id=\"fitting-functions\"></a>\n",
     "\n",
-    "In order to extract the coefficients $a_{\\mu}, b_{\\nu}$, we need to know what function we expect to fit to the measurement data.  The data we will be looking at will be the expectation value of Pauli operators as a function of pulse duration.  In the Heisenberg picture of quantum mechanics, the evolution of the expection value of an operator can be given as\n",
+    "In order to extract the coefficients $a_{\\mu}, b_{\\nu}$, we need to know what function we expect to fit to the measurement data.  The data we will be looking at will be the expectation value of Pauli operators as a function of pulse duration.  In the Heisenberg picture of quantum mechanics, the evolution of the expectation value of an operator can be given as\n",
     "\n",
     "$$\\langle \\hat{O}(t) \\rangle = \\langle e^{i\\hat{H}t} \\hat{O} e^{-i\\hat{H}t} \\rangle$$\n",
     "\n",
@@ -1030,11 +1030,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that we have substantially (but not totally) reduced the frequency shift (due to higher-order levels, etc). At this point we could return to the Hamiltonian tomography experiment\n",
+    "We can see that we have substantially (but not totally) reduced the frequency shift (due to higher-order levels, etc). At this point, we could return to the Hamiltonian tomography experiment.\n",
     "```\n",
     "cr_scheds = build_cr_scheds(qc, qt, cr_times, phase=phase, ZI_MHz=ZI_rate)\n",
     "```\n",
-    "however, since the frame change only affects the control qubit, the results would be identical to the second one. "
+    "However, since the frame change only affects the control qubit, the results would be identical to the second one. "
    ]
   },
   {


### PR DESCRIPTION

# Changes made
I have fixed the following spelling errors:
introducted -> introduced
coeficients -> coefficients
measurments -> measurements
expection -> expectation
Fuctions -> Functions

I have also added full stops at the end of two sentences as they were missing.

# Justification
I have fixed some spelling errors to enhance readability.