### PR TITLE
6.7 Hamiltonian Tomography: Fixing spelling errors

### DIFF
--- a/content/ch-quantum-hardware/hamiltonian-tomography.ipynb
+++ b/content/ch-quantum-hardware/hamiltonian-tomography.ipynb
@@ -74,7 +74,7 @@
     "\\end{split}\n",
     "\\end{equation}\n",
     "\n",
-    "If we let $n$ be the expectation value of the Pauli $\\hat{Z}$ operator on the control qubit, then we can write down these comutators in terms of the expectation values of the target qubit:\n",
+    "If we let $n$ be the expectation value of the Pauli $\\hat{Z}$ operator on the control qubit, then we can write down these commutators in terms of the expectation values of the target qubit:\n",
     "\n",
     "\\begin{equation}\n",
     "\\begin{split}\n",
@@ -118,7 +118,7 @@
     "\\vec{g}_{n} = \\{0, -i\\sqrt{\\Delta^2+\\Omega_x^2+\\Omega_y^2} , i\\sqrt{\\Delta^2+\\Omega_x^2+\\Omega_y^2}\\}_n,\n",
     "$$\n",
     "\n",
-    "where for notationaly simplicity, the subscript $n$ denotes the appropriate values of $\\Delta, \\Omega_x, \\Omega_y,$ given the state of the control qubit. We will not write down the eigenvectors because they are too cumbersome but it is straightforward to find them.  Let $U$ be the transformation into the eigenbasis and let $\\hat{D}_n$ be the diagonal matrix of the eignvalues.  Then we can rewrite the time dependence of $\\vec{r}_n(t)$ as\n",
+    "where for notational simplicity, the subscript $n$ denotes the appropriate values of $\\Delta, \\Omega_x, \\Omega_y,$ given the state of the control qubit. We will not write down the eigenvectors because they are too cumbersome but it is straightforward to find them.  Let $U$ be the transformation into the eigenbasis and let $\\hat{D}_n$ be the diagonal matrix of the eigenvalues.  Then we can rewrite the time dependence of $\\vec{r}_n(t)$ as\n",
     "\n",
     "$$\\vec{r}_n(t) = U^{\\dagger} e^{\\hat{D}_n t} U\\vec{r}_n(0).$$\n",
     "\n",
@@ -908,7 +908,7 @@
    "source": [
     "### Fitting Functions for the CR Ramsey Experiment\n",
     "\n",
-    "We will fit the results to a decaying sinusoid, where the frequency of oscillation is the frequency offset. We will also need to take care of the relation between the control and target qubit frequecies, because that will effect whether the control qubit Stark shift is higher or lower in frequency."
+    "We will fit the results to a decaying sinusoid, where the frequency of oscillation is the frequency offset. We will also need to take care of the relation between the control and target qubit frequencies, because that will effect whether the control qubit Stark shift is higher or lower in frequency."
    ]
   },
   {
@@ -1030,7 +1030,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that we have substantially (but not totally) reduced the frequency shift (due to higher-order levels, etc). At this point we could return to the Hamiltonian tomography experiment\n",
+    "We can see that we have substantially (but not totally) reduced the frequency shift (due to higher-order levels, etc.). At this point we could return to the Hamiltonian tomography experiment\n",
     "```\n",
     "cr_scheds = build_cr_scheds(qc, qt, cr_times, phase=phase, ZI_MHz=ZI_rate)\n",
     "```\n",


### PR DESCRIPTION
# Changes made
I have fixed the following spelling errors:
comutators -> commutators
notationaly -> notational
eignvalues -> eigenvalues
frequecies -> frequencies

I have also replaced 'etc' with 'etc.', which is the correct grammatical form of writing it.

# Justification
I have fixed the spelling errors to improve readability.