### PR TITLE
resolve build error

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+jinja2==2.11.2
 nbconvert==5.6.1
 jupyter-book==0.6.5
 beautifulsoup4


### PR DESCRIPTION
`jinja2` has been updated to version 3.0.0 (as of May 11).
this change is resulting in build failures running nbconvert:

```
jinja2.exceptions.UndefinedError: 'nbformat.notebooknode.NotebookNode object' has no attribute 'tags'
```

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made

`requirements-dev.txt` has been updated to freeze `jinja2` at version `2.11.2`

# Justification

the build can complete and book successfully created
