### PR TITLE
4.1.2 Fixed misspelling of "emphasizing"

### DIFF
--- a/content/ch-applications/vqe-molecules.ipynb
+++ b/content/ch-applications/vqe-molecules.ipynb
@@ -132,7 +132,7 @@
     "![image1](./images/U3_var_form.png)\n",
     "\n",
     "\n",
-    "Moreover, this universal 'variational form' only has 3 parameters and thus can be efficiently optimized. It is worth emphasising that the ability to generate an arbitrary state ensures that during the optimization process, the variational form does not limit the set of attainable states over which the expectation value of $H$ can be taken. Ideally, this ensures that the minimum expectation value is limited only by the capabilities of the classical optimizer. \n",
+    "Moreover, this universal 'variational form' only has 3 parameters and thus can be efficiently optimized. It is worth emphasizing that the ability to generate an arbitrary state ensures that during the optimization process, the variational form does not limit the set of attainable states over which the expectation value of $H$ can be taken. Ideally, this ensures that the minimum expectation value is limited only by the capabilities of the classical optimizer. \n",
     "\n",
     "A less trivial universal variational form may be derived for the 2 qubit case, where two body interactions, and thus entanglement, must be considered to achieve universality. Based on the work presented by *Shende et al.* [3] the following is an example of a universal parameterized 2 qubit circuit:\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
Changed "emphasising" to "emphasizing."

# Justification
"Emphasizing" is the more commonly accepted spelling.
