### PR TITLE
1.3 Fixed explanation of running circuits using statevector simulation

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -427,7 +427,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the results from our circuit, we use `execute` to run our circuit, giving the circuit and the backend as arguments. We then use `.result()` to get the result of this:"
+    "To get the results from our circuit, we use `run` to execute our circuit, giving the circuit and the backend as arguments. We then use `.result()` to get the result of this:"
    ]
   },
   {
@@ -7178,7 +7178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.6.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
# Changes made

Changed "...we use `execute` to run our circuit..." to "...we use `run` to execute our circuit..."

# Justification

The run() method of statevector simulation is used to execute circuit but the opposite was written in the explanation of the code