### PR TITLE
Fixing grammatical errors in 'uncomputation'

### DIFF
--- a/content/ch-algorithms/quantum-key-distribution.ipynb
+++ b/content/ch-algorithms/quantum-key-distribution.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "If Alice and Bob want to use Eve’s classical communication channel to share their key, it is impossible to tell if Eve has made a copy of this key for herself- they must place complete trust in Eve that she is not listening. If, however, Eve provides a quantum communication channel, Alice and Bob no longer need to trust Eve at all- they will know if she tries to read Bob’s message before it gets to Alice.\n",
     "\n",
-    "For some readers, it may be useful to give an idea of how a quantum channel may be physically implemented. An example of a classical channel could be a telephone line; we send electric signals through the line that represent our message (or bits). A proposed example of a quantum communication channel could be some kind of fibre-optic cable, through which we can send individual photons (particles of light). Photons have a property called _polarisation,_ and this polarisation can be one of two states. We can use this to represent a qubit.\n",
+    "For some readers, it may be useful to give an idea of how a quantum channel may be physically implemented. An example of a classical channel could be a telephone line; we send electric signals through the line that represent our message (or bits). A proposed example of a quantum communication channel could be some kind of fiber-optic cable, through which we can send individual photons (particles of light). Photons have a property called _polarisation,_ and this polarisation can be one of two states. We can use this to represent a qubit.\n",
     "\n",
     "\n",
     "## 2. Protocol Overview  \n",

--- a/content/ch-gates/oracles.ipynb
+++ b/content/ch-gates/oracles.ipynb
@@ -1681,7 +1681,7 @@
     "\n",
     "Here we see that the action of $V_f^\\dagger$ does not simply return us to the initial state, but instead leaves the first qubit entangled with unwanted garbage. Any subsequent steps in an algorithm will therefore not run as expected, since the state is not the one that we need.\n",
     "\n",
-    "For this reason we need a way of removing classical garbage from our quantum algorithms. This can be done by a method known as 'uncomputation. We simply need to take another blank variable and apply $V_f$\n",
+    "For this reason we need a way of removing classical garbage from our quantum algorithms. This can be done by a method known as 'uncomputation'. We simply need to take another blank variable and apply $V_f$\n",
     "\n",
     "\n",
     "$$\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
