### PR TITLE
Removing Content Bugs caused by replacing Qasm simulator with Aer Simulator

### DIFF
--- a/content/ch-appendix/qiskit.ipynb
+++ b/content/ch-appendix/qiskit.ipynb
@@ -764,7 +764,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Classical registers and the qasm simulator"
+    "### Classical registers and the Aer simulator"
    ]
   },
   {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
fixes #1180 

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
All details of this PR can be found in above linked issue 