### PR TITLE
Representing -qubit -states.ipynb

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -2170,7 +2170,7 @@
    "source": [
     "qobj = assemble(qc)\n",
     "results = sim.run(qobj).result().get_counts()\n",
-    "plot_histogram(results)"
+    "plot_histogram(result)"
    ]
   },
   {


### PR DESCRIPTION
Representing qubit states(1.3);
in para (1.3) exploring qubits with qiskit last code has showing error:
code line = 2173

given:
```
qobj = assemble(qc)
results = sim.run(qobj).result().get_counts()
plot_histogram(results)
```

correct:
```
qobj = assemble(qc)
results = sim.run(qobj).result().get_counts()
plot_histogram(result)
```

 { 's' is extra in 'result' }

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
