### PR TITLE
terminology / formatting in QHED Chapter

### DIFF
--- a/content/ch-applications/quantum-edge-detection.ipynb
+++ b/content/ch-applications/quantum-edge-detection.ipynb
@@ -23,7 +23,7 @@
     "The QPIE representation uses the probability amplitudes of a quantum state to store the pixel values of a classical image. If we have $n$ -qubits, we have access to up to $2^n$ -states in superposition. In QPIE we take advantage of this fact to design an efficient and robust encoding scheme for Black-and-White (B&W) or RGB images and exponentially reduce the memory required to store the data. That means, for storing a 4-pixel image, we need just 2-qubits; for 8-pixel image we need 3-qubits, and so on. In general, the number of qubits $(n)$ for a $N$-pixel image is calculated as:-\n",
     "\n",
     "$$\n",
-    "n = \\lceil log_2N \\rceil\n",
+    "n = \\lceil \\log_2N \\rceil\n",
     "\\label{eq:Num_qubits} \\tag{1.1}\n",
     "$$\n",
     "\n",
@@ -160,7 +160,7 @@
    "metadata": {},
    "source": [
     "## A Variation of QHED (with an auxiliary qubit)\n",
-    "As discussed in the previous sub-section, we still have a quantum register with $n$-qubits $(n = \\lceil log_2N \\rceil)$ for encoding the $N$-pixel image. However, in this case, we add an extra auxiliary qubit to the register which we can utilize to extend the QHED algorithm and perform computation on both even- and odd-pixel-pairs simultaneously.\n",
+    "As discussed in the previous sub-section, we still have a quantum register with $n$-qubits $(n = \\lceil \\log_2N \\rceil)$ for encoding the $N$-pixel image. However, in this case, we add an extra auxiliary qubit to the register which we can utilize to extend the QHED algorithm and perform computation on both even- and odd-pixel-pairs simultaneously.\n",
     "\n",
     "Like the last time, we initialize to the state $\\ket{Img} = (c_0, c_1, c_2, \\dots, c_{N-2}, c_{N-1})^T$. However, the $H$-gate is now applied to the **auxiliary qubit** this time which is initialized to state $\\ket{0}$.\n",
     "\n",
@@ -260,11 +260,11 @@
     "\n",
     "## Time and Space Complexity analysis of QHED\n",
     "\n",
-    "We briefly discussed about the time complexity of classical edge detection algorithms and realised that it is on the order of $O(2^n)$ for the worst case of the algorithm and $O(mn \\cdot log(mn))$ for some of the more improved classical edge detection techniques [11].\n",
+    "We briefly discussed about the time complexity of classical edge detection algorithms and realised that it is on the order of $O(2^n)$ for the worst case of the algorithm and $O(mn \\cdot \\log(mn))$ for some of the more improved classical edge detection techniques [11].\n",
     "\n",
-    "On the other hand, when one comes to the quantum edge detection techniques, the QSobel algorithm is much faster at $O(n^2)$,and uses the FRQI image representation for encoding an $(N \\times N)$ -pixel image ($N = 2^n$, in a $n$ -qubit system) [4]. However, the FRQI image representation has a complex state preparation process ($[O(n) + O(log^2 n)]$ circuit depth in the worst case) and requires more qubits ( $[1+2N]$ -qubits) to store the image data [1], which is a limited resource in today's NISQ hardware. Moreover, QSobel also suffers from problems with efficient implementation of certain intermediate sub-routines (like COPY and black-box function for gradient calculation) within the algorithm [3].\n",
+    "On the other hand, when one comes to the quantum edge detection techniques, the QSobel algorithm is much faster at $O(n^2)$,and uses the FRQI image representation for encoding an $(N \\times N)$ -pixel image ($N = 2^n$, in a $n$ -qubit system) [4]. However, the FRQI image representation has a complex state preparation process ($[O(n) + O(\\log^2 n)]$ circuit depth in the worst case) and requires more qubits ( $[1+2N]$ -qubits) to store the image data [1], which is a limited resource in today's  hardware. Moreover, QSobel also suffers from problems with efficient implementation of certain intermediate sub-routines (like COPY and black-box function for gradient calculation) within the algorithm [3].\n",
     "\n",
-    "The QHED algorithm which is used here, has more space-efficient image encoding scheme (QPIE) which uses amplitude encoding leading to an exponential decrease in the number of qubits used (just $(n = \\lceil log_2N \\rceil)$ -qubits). However, the time complexity of state-preparation step for image encoding using QPIE is slightly higher at $O[n^2]$ [12], than FRQI. Also, the most efficient implementation of the decrement gate has the circuit depth of $O[poly(n)]$. But, since QHED smartly utilizes the property of the Hadamard-gate, we are able to achieve a time complexity of $O(1)$ for the edge detection procedure (without including state-preparation and amplitude permutation). This is much lower than the $O(n^2)$ complexity required for the QSobel algorithm. Hence, the QHED algorithm gives us a superexponential speedup over classical algorithms and polynomial speedup over the QSobel algorithm.\n",
+    "The QHED algorithm which is used here, has more space-efficient image encoding scheme (QPIE) which uses amplitude encoding leading to an exponential decrease in the number of qubits used (just $(n = \\lceil \\log_2N \\rceil)$ -qubits). However, the time complexity of state-preparation step for image encoding using QPIE is slightly higher at $O[n^2]$ [12], than FRQI. Also, the most efficient implementation of the decrement gate has the circuit depth of $O[\\text{poly}(n)]$. But, since QHED smartly utilizes the property of the Hadamard-gate, we are able to achieve a time complexity of $O(1)$ for the edge detection procedure (without including state-preparation and amplitude permutation). This is much lower than the $O(n^2)$ complexity required for the QSobel algorithm. Hence, the QHED algorithm gives us a superexponential speedup over classical algorithms and polynomial speedup over the QSobel algorithm.\n",
     "\n",
     "**NOTE:** Another aspect that we would need to focus on for making this quantum algorithm work is the number of measurements that one needs to make to get considerable accuracy for the algorithm. Generally, for a $n$ -qubit circuit, one requires $O(2^n)$ measurements to get good precision for the output probabilities. However, if the goal is just to discover some specific patterns in the image, we can perform measurement of a single local observable with the number of measurements just on the order of $O(n^2)$ [3]. However, this limitation is not of the algorithm, but a characteristic of the inherent quantum nature of the system on which the algorithm is run, and hence the quantum and classical edge detection algorithms are not directly comparable only on the basis of the time complexity bounds."
    ]
@@ -1187,7 +1187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Hint:** Since, the above image is very big to encode at once on today's Noisy Intermediate Scale Quantum (NISQ) devices, the solution to this problem would contain the following steps:\n",
+    "**Hint:** Since, the above image is very big to encode at once on today's devices, the solution to this problem would contain the following steps:\n",
     "   1. Find the maximum image size which is simulable on the `statevector_simulator` (Try choosing a power of 2). Let us consider it to be $'w'$.\n",
     "   2. Divide the $256 \\times 256$ image into multiple parts of size $w \\times w$\n",
     "   3. Create circuit for each part and measure the edge detected image.\n",
@@ -1270,7 +1270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Changes made
Fixed some latex formatting / removed "NISQ"

# Justification
- Some of the characters should be in text font (not italics) as they're not individual variables
- We prefer to avoid NISQ, just "noisy" or "today's" devices is fine
