### PR TITLE
[9.1] Update hello_quantum.py

### DIFF
--- a/qiskit-textbook-src/qiskit_textbook/games/hello_quantum.py
+++ b/qiskit-textbook-src/qiskit_textbook/games/hello_quantum.py
@@ -3,7 +3,7 @@
 import copy
 from io import BytesIO
 
-from qiskit import BasicAer as Aer
+from qiskit import Aer
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit import execute
 from qiskit.quantum_info import Statevector


### PR DESCRIPTION
# Changes made
Replace `BasicAer` with `Aer`

# Justification
I don't think `BasicAer` supports `AerSimulator`.
