### PR TITLE
1.3. ch-states Changed formula for normalization constraint

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -2252,7 +2252,7 @@
     "\n",
     "Then:\n",
     "\n",
-    "$$ \\sqrt{|\\alpha|^2 + |\\beta|^2} = 1 $$\n",
+    "$$ |\\alpha|^2 + |\\beta|^2 = 1 $$\n",
     "\n",
     "This explains the factors of $\\sqrt{2}$ you have seen throughout this chapter. In fact, if we try to give `initialize()` a vector that isn’t normalised, it will give us an error:"
    ]
@@ -7206,7 +7206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -7220,7 +7220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Removed square root from normalization constraint formula. --->

# Justification
<!--- The normalization constrains that the sum of the squares of the probability amplitudes needs to be 1, i.e.: |(alpha²)+(beta)²|=1, not sqrt(|(alpha²)+(beta)²|)=1 --->
