### PR TITLE
[3.6] Standardize ket notation in QPE section

### DIFF
--- a/content/ch-algorithms/quantum-phase-estimation.ipynb
+++ b/content/ch-algorithms/quantum-phase-estimation.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "\n",
     "\n",
-    "$$ \\psi_0 = \\lvert 0 \\rangle^{\\otimes n} \\lvert \\psi \\rangle$$\n",
+    "$$ |\\psi_0\\rangle = \\lvert 0 \\rangle^{\\otimes n} \\lvert \\psi \\rangle$$\n",
     "\n",
     " \n",
     "\n",
@@ -95,7 +95,7 @@
     "\n",
     "\n",
     "\n",
-    "$$ \\psi_1 = {\\frac {1}{2^{\\frac {n}{2}}}}\\left(|0\\rangle +|1\\rangle \\right)^{\\otimes n} \\lvert \\psi \\rangle$$\n",
+    "$$ |\\psi_1\\rangle = {\\frac {1}{2^{\\frac {n}{2}}}}\\left(|0\\rangle +|1\\rangle \\right)^{\\otimes n} \\lvert \\psi \\rangle$$\n",
     "\n",
     "\n",
     "\n",
@@ -110,7 +110,7 @@
     "Applying all the $n$ controlled operations $C − U^{2^j}$ with $0\\leq j\\leq n-1$, and using the relation $|0\\rangle \\otimes |\\psi \\rangle +|1\\rangle \\otimes e^{2\\pi i\\theta }|\\psi \\rangle =\\left(|0\\rangle +e^{2\\pi i\\theta }|1\\rangle \\right)\\otimes |\\psi \\rangle$:\n",
     "\n",
     "\\begin{aligned}\n",
-    "\\psi_{2} & =\\frac {1}{2^{\\frac {n}{2}}} \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{n-1}}}|1\\rangle \\right) \\otimes \\cdots \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{1}}}\\vert1\\rangle \\right) \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{0}}}\\vert1\\rangle \\right) \\otimes |\\psi\\rangle\\\\\\\\\n",
+    "|\\psi_{2}\\rangle & =\\frac {1}{2^{\\frac {n}{2}}} \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{n-1}}}|1\\rangle \\right) \\otimes \\cdots \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{1}}}\\vert1\\rangle \\right) \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{0}}}\\vert1\\rangle \\right) \\otimes |\\psi\\rangle\\\\\\\\\n",
     "& = \\frac{1}{2^{\\frac {n}{2}}}\\sum _{k=0}^{2^{n}-1}e^{\\boldsymbol{2\\pi i} \\theta k}|k\\rangle \\otimes \\vert\\psi\\rangle\n",
     "\\end{aligned}\n",
     "where $k$ denotes the integer representation of n-bit binary numbers. \n",
@@ -13474,7 +13474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.10"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Fixes #1227

# Changes made
Updated the wavefunction notation in the 1.2 mathematical foundation section to use the same ket notation as previous sections.

# Justification
The notation used in previous sections always wrote the wavefunction psi as a ket to distinguish it as a quantum state (as opposed to a normal variable).
