### PR TITLE
3.2 A section instructs using incorrect function

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -7111,7 +7111,7 @@
    "metadata": {},
    "source": [
     "#### Quick Exercise\n",
-    "Use `plot_bloch_vector()` or `plot_bloch_sphere_spherical()` to plot a qubit in the states:\n",
+    "Use `plot_bloch_vector()` or `plot_bloch_vector_spherical()` to plot a qubit in the states:\n",
     "1. $|0\\rangle$\n",
     "2. $|1\\rangle$\n",
     "3. $\\tfrac{1}{\\sqrt{2}}(|0\\rangle + |1\\rangle)$\n",


### PR DESCRIPTION
Quick exercise suggests using plot_bloch_sphere_spherical() function. The correct function to use here is plot_bloch_vector_spherical(). 