### PR TITLE
Update reprensentating -qubit-state.ipynb(easy qubit state representation)

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -3275,7 +3275,7 @@
     "\n",
     "(or)\n",
     "\n",
-    "(For custom visual representation of qubit state [click here](https://javafxpert.github.io/grok-bloch/).\n"
+    "You can also try [this interactive Bloch sphere demo](https://javafxpert.github.io/grok-bloch/).\n"
    ]
   },
   {

--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -3273,7 +3273,6 @@
     "\n",
     "(Qiskit has a function to plot a bloch sphere, `plot_bloch_vector()`, but at the time of writing it only takes cartesian coordinates. We have included a function that does the conversion automatically).\n",
     "\n",
-    "(or)\n",
     "\n",
     "You can also try [this interactive Bloch sphere demo](https://javafxpert.github.io/grok-bloch/).\n"
    ]

--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -3271,7 +3271,11 @@
     "\n",
     "Below we have plotted a qubit in the state $|{+}\\rangle$. In this case, $\\theta = \\pi/2$ and $\\phi = 0$.\n",
     "\n",
-    "(Qiskit has a function to plot a bloch sphere, `plot_bloch_vector()`, but at the time of writing it only takes cartesian coordinates. We have included a function that does the conversion automatically).\n"
+    "(Qiskit has a function to plot a bloch sphere, `plot_bloch_vector()`, but at the time of writing it only takes cartesian coordinates. We have included a function that does the conversion automatically).\n",
+    "\n",
+    "(or)\n",
+    "\n",
+    "(For custom visual representation of qubit state [click here](https://javafxpert.github.io/grok-bloch/).\n"
    ]
   },
   {


### PR DESCRIPTION
here i have added line [3275-3278]
for visual representation of qubit it's give clear state of qubit and show how different gate acts on qubit state,
and also difines all gates in easy way!

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
