### PR TITLE
[9.4 Variational Quantum Regression] Fix missing image not showing in textbook

### DIFF
--- a/content/ch-demos/variational-quantum-regression.ipynb
+++ b/content/ch-demos/variational-quantum-regression.ipynb
@@ -23,8 +23,8 @@
    "source": [
     "## Variational Quantum Computing\n",
     "\n",
-    "Variational quantum computing exploits the advantages of both classical computing and quantum computing. In a very general sense, we propose an initial solution to a problem, called an ansatz. In our case our ansatz will be an ansatz parametrised by a and b. We then prepare our qubits (the quantum equivalent of bits on a normal computer) and test how good the ansatz is, using the quantum computer. Testing the ansatz equates to minimising a cost function. We feed the result of this cost function back to the classical computer, and use some classical optimisers to improve on our ansatz, i.e. our initial guesses for a and b. We repeat this process until the ansatz is good enough within some tolerance. \n",
-    "![title](images/vlinreg_circuit.png)"
+    "Variational quantum computing exploits the advantages of both classical computing and quantum computing. In a very general sense, we propose an initial solution to a problem, called an ansatz. In our case our ansatz will be an ansatz parametrised by a and b. We then prepare our qubits (the quantum equivalent of bits on a normal computer) and test how good the ansatz is, using the quantum computer. Testing the ansatz equates to minimising a cost function. We feed the result of this cost function back to the classical computer, and use some classical optimisers to improve on our ansatz, i.e. our initial guesses for a and b. We repeat this process until the ansatz is good enough within some tolerance.\n",
+    "<img src='./images/vlinreg_circuit.png' align='center'>"
    ]
   },
   {


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

Changed ![]() image syntax to <src > syntax so the image can render on online textbook

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

The image wasn't showing on the online textbook
