### PR TITLE
[3.10] Broken hyperlink for "Understanding Quantum Teleportation" section header

### DIFF
--- a/content/ch-algorithms/teleportation.ipynb
+++ b/content/ch-algorithms/teleportation.ipynb
@@ -22455,7 +22455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Understanding Quantum Teleportation <a id=\"understanding-qt\">"
+    "## 4. Understanding Quantum Teleportation <a id=\"understanding-qt\"></a>"
    ]
   },
   {
@@ -24535,7 +24535,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #1268

# Changes made
Closed the hyperlink tag on the section header.

# Justification
This fixes the broken hyperlink so we can link to this section header.
