### PR TITLE
Make the name for controlled U gates consistent

### DIFF
--- a/content/ch-algorithms/quantum-phase-estimation.ipynb
+++ b/content/ch-algorithms/quantum-phase-estimation.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "\n",
     "\n",
-    "iii. **Controlled Unitary Operations**: We need to introduce the controlled unitary $C-U$ that applies the unitary operator $U$ on the target register only if its corresponding control bit is $|1\\rangle$. Since $U$ is a unitary operator with eigenvector $|\\psi\\rangle$ such that $U|\\psi \\rangle =e^{\\boldsymbol{2\\pi i} \\theta }|\\psi \\rangle$, this means: \n",
+    "iii. **Controlled Unitary Operations**: We need to introduce the controlled unitary $CU$ that applies the unitary operator $U$ on the target register only if its corresponding control bit is $|1\\rangle$. Since $U$ is a unitary operator with eigenvector $|\\psi\\rangle$ such that $U|\\psi \\rangle =e^{\\boldsymbol{2\\pi i} \\theta }|\\psi \\rangle$, this means: \n",
     "\n",
     "\n",
     "\n",
@@ -107,7 +107,7 @@
     "\n",
     "\n",
     "\n",
-    "Applying all the $n$ controlled operations $C − U^{2^j}$ with $0\\leq j\\leq n-1$, and using the relation $|0\\rangle \\otimes |\\psi \\rangle +|1\\rangle \\otimes e^{2\\pi i\\theta }|\\psi \\rangle =\\left(|0\\rangle +e^{2\\pi i\\theta }|1\\rangle \\right)\\otimes |\\psi \\rangle$:\n",
+    "Applying all the $n$ controlled operations $CU^{2^j}$ with $0\\leq j\\leq n-1$, and using the relation $|0\\rangle \\otimes |\\psi \\rangle +|1\\rangle \\otimes e^{2\\pi i\\theta }|\\psi \\rangle =\\left(|0\\rangle +e^{2\\pi i\\theta }|1\\rangle \\right)\\otimes |\\psi \\rangle$:\n",
     "\n",
     "\\begin{aligned}\n",
     "|\\psi_{2}\\rangle & =\\frac {1}{2^{\\frac {n}{2}}} \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{n-1}}}|1\\rangle \\right) \\otimes \\cdots \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{1}}}\\vert1\\rangle \\right) \\otimes \\left(|0\\rangle+{e^{\\boldsymbol{2\\pi i} \\theta 2^{0}}}\\vert1\\rangle \\right) \\otimes |\\psi\\rangle\\\\\\\\\n",
@@ -1737,7 +1737,7 @@
     "repetitions = 1\n",
     "for counting_qubit in range(3):\n",
     "    for i in range(repetitions):\n",
-    "        qpe.cp(math.pi/4, counting_qubit, 3); # This is C-U\n",
+    "        qpe.cp(math.pi/4, counting_qubit, 3); # This is CU\n",
     "    repetitions *= 2\n",
     "qpe.draw()"
    ]


### PR DESCRIPTION
In one place, the controlled U gate is called CU. In three others, it was called C-U. Here I’m changing them to all say CU.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
I changed three occurrences of C-U (for a controlled U gate) to CU, to be consistent with the first time the CU is introduced.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
My decision here is to change C-U to CU, because the hyphen was rendering in LaTeX math as a minus. That was a source of confusion for me as a first-time reader: it looked like some gate C, minus some gate U applied 2^j times. On the other hand, if a hyphen is preferable for some other reason I don’t know about, then `C\text{-}U` would be a good option.