### PR TITLE
Remove Abe from contact details

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ If you'd like to contribute to Qiskit Textbook, please take a look at our [contr
 The materials and associated source code of this open-source textbook are licensed under [Apache License 2.0](http://github.com/qiskit-community/qiskit-textbook/blob/main/LICENSE.txt).
 
 # Contact
-For any issues, please contact Frank Harkins in the [Qiskit Slack workspace](https://ibm.co/joinqiskitslack). You can also email Frank Harkins (francis.harkins@ibm.com) and Abraham Asfaw (abraham.asfaw@ibm.com).
+For any issues, please contact Frank Harkins in the [Qiskit Slack workspace](https://ibm.co/joinqiskitslack). You can also email Frank Harkins (francis.harkins@ibm.com).


### PR DESCRIPTION
# Changes made
Removed Abe's contact details from the textbook.

# Justification
Abe no longer works at IBM and any emails to his account will not be received.
