### PR TITLE
environment.yml: allow any Python 3.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,11 @@ name: base
 channels:
 - conda-forge
 dependencies:
-- python==3.7
+- python==3.7.*
 - pip==19.*
 - cython
 - numpy
-- matplotlib
+- matplotlib-base
 - torchvision
 - qutip
 - sympy


### PR DESCRIPTION
- pin Python to 3.7.* instead of 3.7.0 (`=3.7` is the same as `==3.7.*`, but `==3.7` is `==3.7.0`)
- depend on matplotlib-base instead of full matplotlib, which avoids pulling in large qt dependency, which goes unused in containers

This fixed installation e.g. on mybinder.org, where the strict pinning of old Python 3.7 caused an unresolvable env.