### PR TITLE
[1.2, 4.3] Describe classical bit role in timing graph

### DIFF
--- a/content/ch-states/atoms-computation.ipynb
+++ b/content/ch-states/atoms-computation.ipynb
@@ -4714,7 +4714,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The two bits we want to add are encoded in the qubits 0 and 1. The above example encodes a ```1``` in both these qubits, and so it seeks to find the solution of ```1+1```. The result will be a string of two bits, which we will read out from the qubits 2 and 3. All that remains is to fill in the actual program, which lives in the blank space in the middle.\n",
+    "The two bits we want to add are encoded in the qubits 0 and 1. The above example encodes a ```1``` in both these qubits, and so it seeks to find the solution of ```1+1```. The result will be a string of two bits, which we will read out from the qubits 2 and 3 and store in classical bits 0 and 1, respectively. All that remains is to fill in the actual program, which lives in the blank space in the middle.\n",
     "\n",
     "The dashed lines in the image are just to distinguish the different parts of the circuit (although they can have more interesting uses too). They are made by using the `barrier` command.\n",
     "\n",
@@ -7412,7 +7412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -9059,5 +9059,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
Adds a bit of text to the Adding with Qiskit section of Atoms of
Computation.

# Justification
This should help to clarify the function of classical bit indices
in timing graphs to new readers.

Resolves #1309
