### PR TITLE
[2.6] Fixed Grammar Error "to copies"

### DIFF
--- a/content/ch-gates/oracles.ipynb
+++ b/content/ch-gates/oracles.ipynb
@@ -2079,7 +2079,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The effect of this is to copies the information over (if you have heard of the no-cloning theorem, note that this is not the same process). Specifically, it transforms the state in the following way.\n",
+    "The effect of this is to copy the information over (if you have heard of the no-cloning theorem, note that this is not the same process). Specifically, it transforms the state in the following way.\n",
     "\n",
     "$$\n",
     "\\left| x,f(x),g(x),0 \\right\\rangle \\rightarrow \\left| x,f(x),g(x),f(x) \\right\\rangle.\n",


### PR DESCRIPTION
# Changes made
"The effect of this is to ~~copies~~ **copy** the information over..."

# Justification
The verb after “to” should be in the base form.