### PR TITLE
Changed tensor to kronecker

### DIFF
--- a/content/ch-gates/multiple-qubits-entangled-states.ipynb
+++ b/content/ch-gates/multiple-qubits-entangled-states.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "$$ |a_{00}|^2 + |a_{01}|^2 + |a_{10}|^2 + |a_{11}|^2 = 1$$\n",
     "\n",
-    "If we have two separated qubits, we can describe their collective state using the tensor product:\n",
+    "If we have two separated qubits, we can describe their collective state using the kronecker product:\n",
     "\n",
     "$$ |a\\rangle = \\begin{bmatrix} a_0 \\\\ a_1 \\end{bmatrix}, \\quad |b\\rangle = \\begin{bmatrix} b_0 \\\\ b_1 \\end{bmatrix} $$\n",
     "\n",
@@ -59,7 +59,7 @@
     "|ba\\rangle = |b\\rangle \\otimes |a\\rangle = \\begin{bmatrix} b_0 \\times \\begin{bmatrix} a_0 \\\\ a_1 \\end{bmatrix} \\\\ b_1 \\times \\begin{bmatrix} a_0 \\\\ a_1 \\end{bmatrix} \\end{bmatrix} = \\begin{bmatrix} b_0 a_0 \\\\ b_0 a_1 \\\\ b_1 a_0 \\\\ b_1 a_1 \\end{bmatrix}\n",
     "$$\n",
     "\n",
-    "And following the same rules, we can use the tensor product to describe the collective state of any number of qubits. Here is an example with three qubits:\n",
+    "And following the same rules, we can use the kronecker product to describe the collective state of any number of qubits. Here is an example with three qubits:\n",
     "\n",
     "$$ \n",
     "|cba\\rangle = \\begin{bmatrix} c_0 b_0 a_0 \\\\ c_0 b_0 a_1 \\\\ c_0 b_1 a_0 \\\\ c_0 b_1 a_1 \\\\\n",
@@ -177,7 +177,7 @@
    "source": [
     "### 1.2 Quick Exercises: <a id=\"ex1\"></a>\n",
     "\n",
-    "1.\tWrite down the tensor product of the qubits:    \n",
+    "1.\tWrite down the kronecker product of the qubits:    \n",
     "    a)\t$|0\\rangle|1\\rangle$    \n",
     "    b)\t$|0\\rangle|+\\rangle$    \n",
     "    c)\t$|+\\rangle|1\\rangle$    \n",
@@ -201,7 +201,7 @@
     "X|0\\rangle = \\begin{bmatrix} 0 & 1 \\\\ 1 & 0 \\end{bmatrix}\\begin{bmatrix} 1 \\\\ 0 \\end{bmatrix} = \\begin{bmatrix} 0 \\\\ 1\\end{bmatrix}\n",
     "$$\n",
     "\n",
-    "but it may not be clear how an X-gate would act on a qubit in a multi-qubit vector. Fortunately, the rule is quite simple; just as we used the tensor product to calculate multi-qubit statevectors, we use the tensor product to calculate matrices that act on these statevectors. For example, in the circuit below:"
+    "but it may not be clear how an X-gate would act on a qubit in a multi-qubit vector. Fortunately, the rule is quite simple; just as we used the kronecker product to calculate multi-qubit statevectors, we use the tensor product to calculate matrices that act on these statevectors. For example, in the circuit below:"
    ],
    "metadata": {}
   },
@@ -232,7 +232,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "we can represent the simultaneous operations (H & X) using their tensor product:\n",
+    "we can represent the simultaneous operations (H & X) using their kronecker product:\n",
     "\n",
     "$$\n",
     "X|q_1\\rangle \\otimes H|q_0\\rangle = (X\\otimes H)|q_1 q_0\\rangle\n",
@@ -334,7 +334,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "If we want to apply a gate to only one qubit at a time (such as in the circuit below), we describe this using tensor product with the identity matrix, e.g.:\n",
+    "If we want to apply a gate to only one qubit at a time (such as in the circuit below), we describe this using kronecker product with the identity matrix, e.g.:\n",
     "\n",
     "$$ X \\otimes I $$"
    ],
@@ -403,7 +403,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "We can see Qiskit has performed the tensor product:\n",
+    "We can see Qiskit has performed the kronecker product:\n",
     "$$\n",
     "X \\otimes I =\n",
     "\\begin{bmatrix} 0 & I \\\\\n",
@@ -419,9 +419,9 @@
     "### 2.1 Quick Exercises: <a id=\"ex2\"></a>\n",
     "\n",
     "1. Calculate the single qubit unitary ($U$) created by the sequence of gates: $U = XZH$. Use Qiskit's Aer simulator to check your results.\n",
-    "2. Try changing the gates in the circuit above. Calculate their tensor product, and then check your answer using the Aer simulator.\n",
+    "2. Try changing the gates in the circuit above. Calculate their kronecker product, and then check your answer using the Aer simulator.\n",
     "\n",
-    "**Note:** Different books, softwares and websites order their qubits differently. This means the tensor product of the same circuit can look very different. Try to bear this in mind when consulting other sources. \n"
+    "**Note:** Different books, softwares and websites order their qubits differently. This means the kronecker product of the same circuit can look very different. Try to bear this in mind when consulting other sources. \n"
    ],
    "metadata": {}
   },


### PR DESCRIPTION
kronecker product is more precise than tensor product.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
