### PR TITLE
[README.md] Add pipenv install instructions to

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The Qiskit Textbook provides some tools and widgets specific to the Textbook. Th
 pip install git+https://github.com/qiskit-community/qiskit-textbook.git#subdirectory=qiskit-textbook-src
 ```
 
+Or, if you prefer using [pipenv](https://pypi.org/project/pipenv/):
+
+```
+pipenv install "git+https://github.com/qiskit-community/qiskit-textbook.git#subdirectory=qiskit-textbook-src&egg=qiskit_textbook"
+```
+
 Alternatively, you can download the folder [`qiskit-textbook-src`](qiskit-textbook-src) and run:
 
 ```


### PR DESCRIPTION
# Changes made
Added pipenv install instructions to README.md

The quotes around the URL seem to be necessary in order to recognize the egg fragment

# Justification
I guess you can argue about `pipenv` but a lot of people use it for virtual environments. Getting the textbook installed on pipenv wasn't entirely trivial and took me like 2 minutes of trial and error.