### PR TITLE
[4.1.3] switch cost and mixing unitary

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -3363,8 +3363,8 @@
     "qc_qaoa = QuantumCircuit(nqubits)\n",
     "\n",
     "qc_qaoa.append(qc_0, [i for i in range(0, nqubits)])\n",
-    "qc_qaoa.append(qc_mix, [i for i in range(0, nqubits)])\n",
     "qc_qaoa.append(qc_p, [i for i in range(0, nqubits)])\n",
+    "qc_qaoa.append(qc_mix, [i for i in range(0, nqubits)])\n",
     "\n",
     "qc_qaoa.decompose().decompose().draw()"
    ]


### PR DESCRIPTION
shouldn't the 2-qubit operations come first?