### PR TITLE
[1.2] Added space between 'QuantumCircuit.' and 'The'

### DIFF
--- a/content/ch-states/atoms-computation.ipynb
+++ b/content/ch-states/atoms-computation.ipynb
@@ -206,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This circuit, which we have called `qc_output`, is created by Qiskit using `QuantumCircuit`.The `QuantumCircuit` takes the number of qubits in the quantum circuit as an argument. \n",
+    "This circuit, which we have called `qc_output`, is created by Qiskit using `QuantumCircuit`. The `QuantumCircuit` takes the number of qubits in the quantum circuit as an argument. \n",
     "\n",
     "The extraction of outputs in a quantum circuit is done using an operation called `measure_all()`. Each measurement tells a specific qubit to give an output to a specific output bit. The command `qc_output.measure_all()` adds a measurement to each qubit in the circuit `qc_output`, and also adds some classical bits to write the output to."
    ]


### PR DESCRIPTION
# Changes made
[1.2] Added space between 'QuantumCircuit.' and 'The'

# Justification
Minor grammar mistake
