### PR TITLE
[3.12] fix encode_message character validation

### DIFF
--- a/content/ch-algorithms/superdense-coding.ipynb
+++ b/content/ch-algorithms/superdense-coding.ipynb
@@ -223,7 +223,7 @@
     "    Raises:\n",
     "        ValueError if msg is wrong length or contains invalid characters\n",
     "    \"\"\"\n",
-    "    if len(msg) != 2 or not set([0,1]).issubset({0,1}):\n",
+    "    if len(msg) != 2 or not set(msg).issubset({\"0\",\"1\"}):\n",
     "        raise ValueError(f\"message '{msg}' is invalid\")\n",
     "    if msg[1] == \"1\":\n",
     "        qc.x(qubit)\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
Fixed the encode_message function character validation for superdense coding

# Justification
Previously the function claimed to validate characters in the comments but actually did nothing meaningful.
