### PR TITLE
[2.3] swapped control & target qubit in equations

### DIFF
--- a/content/ch-gates/phase-kickback.ipynb
+++ b/content/ch-gates/phase-kickback.ipynb
@@ -307,7 +307,7 @@
     "\n",
     "$$ |{+}{+}\\rangle = \\tfrac{1}{2}(|00\\rangle + |01\\rangle + |10\\rangle + |11\\rangle) $$\n",
     "\n",
-    "Since the CNOT swaps the amplitudes of $|01\\rangle$ and $|11\\rangle$, we see no change:"
+    "Since the CNOT swaps the amplitudes of $|10\\rangle$ and $|11\\rangle$, we see no change:"
    ]
   },
   {
@@ -8447,7 +8447,7 @@
    "source": [
     "This creates the state:\n",
     "\n",
-    "$$ |{-}{+}\\rangle = \\tfrac{1}{2}(|00\\rangle + |01\\rangle - |10\\rangle - |11\\rangle) $$"
+    "$$ |{+}{-}\\rangle = \\tfrac{1}{2}(|00\\rangle - |01\\rangle + |10\\rangle - |11\\rangle) $$"
    ]
   },
   {
@@ -16337,11 +16337,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the CNOT acts on this state, we will swap the amplitudes of $|01\\rangle$ and $|11\\rangle$, resulting in the state:\n",
+    "If the CNOT acts on this state, we will swap the amplitudes of $|10\\rangle$ and $|11\\rangle$, resulting in the state:\n",
     "\n",
     "$$\n",
     "\\begin{aligned}\n",
-    "\\text{CNOT}|{-}{+}\\rangle & = \\tfrac{1}{2}(|00\\rangle - |01\\rangle - |10\\rangle + |11\\rangle) \\\\\n",
+    "\\text{CNOT}|{+}{-}\\rangle & = \\tfrac{1}{2}(|00\\rangle - |01\\rangle - |10\\rangle + |11\\rangle) \\\\\n",
     "                           & = |{-}{-}\\rangle\n",
     "\\end{aligned}\n",
     "$$\n",


### PR DESCRIPTION
# Changes made
Swapped control & target qubit of CNOTs in the text of chapter 2.3.1

# Justification
The control & target qubit of the CNOTs in the text of chapter 2.3.1 were the wrong way around.
The context/code describes the [CNOT gate acting on the state `|+->`][1] but the the state `|-+>` is used in equations.

 [1]: https://en.wikipedia.org/wiki/Controlled_NOT_gate#Details_of_the_computation