### PR TITLE
Eigenvectors are not compatible, and must have 1/sqrt(2) multiplications.

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -209,7 +209,7 @@
     "$$|01\\rangle_{n_{l}}\\quad\\text{and}\\quad|10\\rangle_{n_{l}}$$\n",
     "\n",
     "The eigenvectors are, respectively,\n",
-    "$$|u_{1}\\rangle=\\begin{pmatrix}1 \\\\ -1\\end{pmatrix}\\quad\\text{and}\\quad|u_{2}\\rangle=\\begin{pmatrix}1 \\\\ 1\\end{pmatrix}$$\n",
+    "$$|u_{1}\\rangle=\frac{1}{\sqrt{2}}\\begin{pmatrix}1 \\\\ -1\\end{pmatrix}\\quad\\text{and}\\quad|u_{2}\\rangle=\frac{1}{\sqrt{2}}\\begin{pmatrix}1 \\\\ 1\\end{pmatrix}$$\n",
     "Again, keep in mind that one does not need to compute the eigenvectors for the HHL implementation. In fact, a general Hermitian matrix $A$ of dimension $N$ can have up to $N$ different eigenvalues, therefore calculating them would take $\\mathcal{O}(N)$ time and the quantum advantage would be lost.\n",
     "\n",
     "We can then write $|b\\rangle$ in the eigenbasis of $A$ as\n",


### PR DESCRIPTION
Eigenvectors should have \frac{1}{\sqrt{2}} multiplication, otherwise \ket{b} is not equal to \ket{0} unless normalized again.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
