### PR TITLE
Fixed #1374

### DIFF
--- a/content/ch-algorithms/grover.ipynb
+++ b/content/ch-algorithms/grover.ipynb
@@ -1784,7 +1784,7 @@
     "# Load IBM Q account and get the least busy backend device\n",
     "provider = IBMQ.load_account()\n",
     "provider = IBMQ.get_provider(\"ibm-q\")\n",
-    "device = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= 3 and \n",
+    "device = least_busy(provider.backends(filters=lambda int(x: x.configuration().n_qubits) >= 3 and \n",
     "                                   not x.configuration().simulator and x.status().operational==True))\n",
     "print(\"Running on current least busy device: \", device)"
    ]
@@ -4265,7 +4265,7 @@
     }
    ],
    "source": [
-    "backend = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= 3 and \n",
+    "backend = least_busy(provider.backends(filters=lambda int(x: x.configuration().n_qubits) >= 3 and \n",
     "                                   not x.configuration().simulator and x.status().operational==True))\n",
     "print(\"least busy backend: \", backend)"
    ]


### PR DESCRIPTION
Fixed [ch-algorithms/Grover's Algorithm] 3.1.2 and 2.1.2 #1374

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
fixed by typecasting `x.configuration().n_qubits` inside the lambda function as:
```
device = least_busy(provider.backends(filters=lambda x: int(x.configuration().n_qubits) >= 3 and 
                                   not x.configuration().simulator and x.status().operational==True))
print("Running on current least busy device: ", device)
```
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
Throws `TypeError: '>=' not supported between instances of 'str' and 'int'` on running the code example

