### PR TITLE
Fix build errors

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -209,7 +209,7 @@
     "$$|01\\rangle_{n_{l}}\\quad\\text{and}\\quad|10\\rangle_{n_{l}}$$\n",
     "\n",
     "The eigenvectors are, respectively,\n",
-    "$$|u_{1}\\rangle=\frac{1}{\sqrt{2}}\\begin{pmatrix}1 \\\\ -1\\end{pmatrix}\\quad\\text{and}\\quad|u_{2}\\rangle=\frac{1}{\sqrt{2}}\\begin{pmatrix}1 \\\\ 1\\end{pmatrix}$$\n",
+    "$$|u_{1}\\rangle=\\frac{1}{\\sqrt{2}}\\begin{pmatrix}1 \\\\ -1\\end{pmatrix}\\quad\\text{and}\\quad|u_{2}\\rangle=\\frac{1}{\\sqrt{2}}\\begin{pmatrix}1 \\\\ 1\\end{pmatrix}$$\n",
     "Again, keep in mind that one does not need to compute the eigenvectors for the HHL implementation. In fact, a general Hermitian matrix $A$ of dimension $N$ can have up to $N$ different eigenvalues, therefore calculating them would take $\\mathcal{O}(N)$ time and the quantum advantage would be lost.\n",
     "\n",
     "We can then write $|b\\rangle$ in the eigenbasis of $A$ as\n",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 jinja2==2.11.3
 nbconvert==5.6.1
 jupyter-book==0.6.5
+markupsafe==2.0.1
 beautifulsoup4
 


### PR DESCRIPTION
# Changes made
- Pinned markupsafe to `2.0.1`
- Fixed syntax errors in HHL notebook

# Justification
- Markupsafe introduced breaking changes which broke build process (see https://github.com/pallets/markupsafe/issues/284#issuecomment-1044168203).
- Backslashes were not escaped in HHL notebook
