### PR TITLE
[1.4] Fix Japanese in single-qubit-gates.ipynb

### DIFF
--- a/i18n/locales/ja/ch-states/single-qubit-gates.ipynb
+++ b/i18n/locales/ja/ch-states/single-qubit-gates.ipynb
@@ -442,7 +442,7 @@
     "\n",
     "$$ X = HZH $$\n",
     "\n",
-    "これにZ基底を作用させると、Hゲートは量子ビットをX基底に変換し、ZゲートはX基底にNOTを作用させ、最後のHゲートがZ基底を返します。\n",
+    "これをZ基底に作用させると、Hゲートは量子ビットをX基底に変換し、ZゲートはX基底にNOTを作用させ、最後のHゲートがZ基底を返します。\n",
     "これは行列を掛け合わせることで確かめられます:\n",
     "$$ HZH=\\frac{1}{\\sqrt{2}}\\begin{bmatrix} 1 &  1\\\\ 1 & -1\\end{bmatrix} \\begin{bmatrix} 1 &  0\\\\ 0 & -1\\end{bmatrix} \\frac{1}{\\sqrt{2}} \\begin{bmatrix} 1 &  1 \\\\ 1 & -1\\end{bmatrix} \n",
     "= \\begin{bmatrix} 0 &  1 \\\\ 1 & 0\\end{bmatrix} = X $$\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->

- Modify confusing texts

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

- Some Japanese seemed confusing, so I fixed them: the gates HZH act on the Z-basis rather than the Z-basis acting on the gates.