### PR TITLE
4.1.2 Fixed misspelling of 'parameters'

### DIFF
--- a/content/ch-applications/vqe-molecules.ipynb
+++ b/content/ch-applications/vqe-molecules.ipynb
@@ -216,7 +216,7 @@
     "    return output_distr\n",
     "\n",
     "def objective_function(params):\n",
-    "    # Obtain a quantum circuit instance from the paramters\n",
+    "    # Obtain a quantum circuit instance from the parameters\n",
     "    qc = get_var_form(params)\n",
     "    # Execute the quantum circuit to obtain the probability distribution associated with the current parameters\n",
     "    t_qc = transpile(qc, backend)\n",


### PR DESCRIPTION
# Changes made
<!--- Please state what you did --->

fixed spelling of parameters

# Justification

typo
