### PR TITLE
[3.4] Fix minimum number of qubits required for IBMQ.

### DIFF
--- a/content/ch-algorithms/simon.ipynb
+++ b/content/ch-algorithms/simon.ipynb
@@ -2856,7 +2856,7 @@
     "# Load our saved IBMQ accounts and get the least busy backend device with less than or equal to 5 qubits\n",
     "IBMQ.load_account()\n",
     "provider = IBMQ.get_provider(hub='ibm-q')\n",
-    "backend = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= n and \n",
+    "backend = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= n*2 and \n",
     "                                   not x.configuration().simulator and x.status().operational==True))\n",
     "print(\"least busy backend: \", backend)\n",
     "\n",

--- a/i18n/locales/ja/ch-algorithms/simon.ipynb
+++ b/i18n/locales/ja/ch-algorithms/simon.ipynb
@@ -527,7 +527,7 @@
     "IBMQ.save_account('YOUR_TOKEN')\n",
     "IBMQ.load_account()\n",
     "provider = IBMQ.get_provider(hub='ibm-q')\n",
-    "backend = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= n and \n",
+    "backend = least_busy(provider.backends(filters=lambda x: x.configuration().n_qubits >= n*2 and \n",
     "                                   not x.configuration().simulator and x.status().operational==True))\n",
     "print(\"least busy backend: \", backend)\n",
     "\n",


### PR DESCRIPTION
# Changes made
Changed the number of qubits required when running Simon's algorithm on a real machine.

# Justification
When b = "11", Simon's algorithm requires n*2 qubits.
