### PR TITLE
Fix BibTeX file URL

### DIFF
--- a/content/qiskit-textbook.bib
+++ b/content/qiskit-textbook.bib
@@ -2,5 +2,5 @@
 	author = {Amira Abbas and Stina Andersson and Abraham Asfaw and Antonio Corcoles and Luciano Bello and Yael Ben-Haim and Mehdi Bozzo-Rey and Sergey Bravyi and Nicholas Bronn and Lauren Capelluto and Almudena Carrera Vazquez and Jack Ceroni and Richard Chen and Albert Frisch and Jay Gambetta and Shelly Garion and Leron Gil and Salvador De La Puente Gonzalez and Francis Harkins and Takashi Imamichi and Pavan Jayasinha and Hwajung Kang and Amir h. Karamlou and Robert Loredo and David McKay and Alberto Maldonado and Antonio Macaluso and Antonio Mezzacapo and Zlatko Minev and Ramis Movassagh and Giacomo Nannicini and Paul Nation and Anna Phan and Marco Pistoia and Arthur Rattew and Joachim Schaefer and Javad Shabani and John Smolin and John Stenger and Kristan Temme and Madeleine Tod and Ellinor Wanzambi and Stephen Wood and James Wootton.},
 	title = {Learn Quantum Computation Using Qiskit},
 	year = {2020},
-	url = {http://community.qiskit.org/textbook},
+	url = {https://qiskit.org/textbook/},
 }


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made

- Fix URL in BibTeX file

<!--- Please state what you did --->

# Justification

- Use SSL(`https`) URL
- Now `https://community.qiskit.org/textbook` has been moved so I fix it
    ```console
    $ curl -I https://community.qiskit.org/textbook
    HTTP/2 301
    date: Fri, 29 Jul 2022 04:51:55 GMT
    location: https://qiskit.org/textbook
    expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
    server: cloudflare
    cf-ray: 73233dffac1914d4-NRT
    ```
    ```console
    $ curl -I https://qiskit.org/textbook
    HTTP/2 301
    date: Fri, 29 Jul 2022 04:53:22 GMT
    location: https://qiskit.org/textbook/
    expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
    server: cloudflare
    cf-ray: 7323401c8ad7afe1-NRT
    ```

# Discussion

- This repository has another BibTeX file 👀 
     -  https://github.com/qiskit-community/qiskit-textbook/blob/09212862c48a09c842a1e11d4df339d28a6d6cef/i18n/locales/ja/qiskit-textbook.bib#L1-L8
     - Should I fix also this file?
