### PR TITLE
[2.5] Fixed expression result to identity matrix not scalar

### DIFF
--- a/content/ch-gates/proving-universality.ipynb
+++ b/content/ch-gates/proving-universality.ipynb
@@ -75,7 +75,7 @@
     "The Hermitian conjugate $M^\\dagger$ of a matrix $M$ is the combination of the transpose \\(replace the bottom left element with the top right, and so on\\) and the complex conjugate of each element. Two families of matrices that are very important to quantum computing are defined by their relationship with the Hermitian conjugate. One is the family of unitary matrices, for which\n",
     "\n",
     "$$\n",
-    "U U^\\dagger = U^\\dagger U = 1.\n",
+    "U U^\\dagger = U^\\dagger U = I.\n",
     "$$\n",
     "\n",
     "This means that the Hermitian conjugate of a unitary is its inverse: another unitary $U^\\dagger$ with the power to undo the effects of $U$. All gates in quantum computing, with the exception of measurement and reset operations, can be represented by unitary matrices.\n",

--- a/content/ch-gates/proving-universality.ipynb
+++ b/content/ch-gates/proving-universality.ipynb
@@ -110,7 +110,7 @@
     "\n",
     "where the $\\lambda_j$ are the eigenvalues of the matrix and $|h_j\\rangle$ are the corresponding eigenstates.\n",
     "\n",
-    "For unitaries, applying the $U U^\\dagger=1$ condition in this diagonal form implies that $\\lambda_j \\lambda_j^* = 1$. The eigenvalues are therefore always complex numbers of magnitude 1, and so can be expressed $e^{ih_j}$ for some real value $h_j$. For Hermitian matrices the condition $H = H^\\dagger$ implies $\\lambda_j = \\lambda_j^*$, and hence that all eigenvalues are real.\n",
+    "For unitaries, applying the $U U^\\dagger=I$ condition in this diagonal form implies that $\\lambda_j \\lambda_j^* = 1$. The eigenvalues are therefore always complex numbers of magnitude 1, and so can be expressed $e^{ih_j}$ for some real value $h_j$. For Hermitian matrices the condition $H = H^\\dagger$ implies $\\lambda_j = \\lambda_j^*$, and hence that all eigenvalues are real.\n",
     "\n",
     "These two types of matrices therefore differ only in that one must have real numbers for eigenvalues, and the other must have complex exponentials of real numbers. This means that, for every unitary, we can define a corresponding Hermitian matrix. For this we simply reuse the same eigenstates, and use the $h_j$ from each $e^{ih_j}$ as the corresponding eigenvalue.\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Updated equivalence between the product of a unitary matrix and its Hermitian conjugate

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The product of a unitary matrix and its Hermitian conjugate is the identity matrix (I), not a scalar (1)
