### PR TITLE
Update nbconvert and jinja

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-jinja2==2.11.3
-nbconvert==5.6.1
+jinja2==3.1.2
+nbconvert==6.5.1
 jupyter-book==0.6.5
 markupsafe==2.0.1
 ipython_genutils


### PR DESCRIPTION
https://github.com/qiskit-community/qiskit-textbook/pull/1087 pinned jinja 2.x to resolve build issues with nbconvert 5.x.

Nbconvert 6.x is out now and works with jinja 3.x so we should hopefully be able to update both.

This will resolve https://github.com/qiskit-community/qiskit-textbook/pull/1466. 