### PR TITLE
[Lab 2. Quantum Measurement] Fixed the #1476

### DIFF
--- a/content/ch-labs/Lab02_QuantumMeasurement.ipynb
+++ b/content/ch-labs/Lab02_QuantumMeasurement.ipynb
@@ -704,7 +704,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.ignis.mitigation.measurement import *"
+    "from qiskit.utils.mitigation import *"
    ]
   },
   {


### PR DESCRIPTION
[Lab 2. Quantum Measurement] Lab uses Ignis (unmaintained since July 2022) [#1476](https://github.com/qiskit-community/qiskit-textbook/issues/1476)

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Changed `from qiskit.ignis.mitigation.measurement import *` to `from qiskit.utils.mitigation import *`
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
The code example in [Lab 2](https://qiskit.org/textbook/ch-labs/Lab02_QuantumMeasurement.html) uses `qiskit.ignis`, which is unmaintained since July 2022 after being deprecated in Dec 2021.
