### PR TITLE
[4.1.3] reverse bitstrings

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -3443,7 +3443,7 @@
     "    sum_count = 0\n",
     "    for bitstring, count in counts.items():\n",
     "        \n",
-    "        obj = maxcut_obj(bitstring, G)\n",
+    "        obj = maxcut_obj(bitstring[::-1], G)\n",
     "        avg += obj * count\n",
     "        sum_count += count\n",
     "        \n",


### PR DESCRIPTION
# Changes made
Reverse bit-strings before evaluating cut sizes

# Justification
Bit-strings in the counts dictionary are in little-endian format. However, input expected by the cut size evaluation function is not.

fixes #1495 

@bernalde