### PR TITLE
[5.5] Fix the extra ')'

### DIFF
--- a/content/ch-quantum-hardware/density-matrix.ipynb
+++ b/content/ch-quantum-hardware/density-matrix.ipynb
@@ -3143,7 +3143,7 @@
     "\n",
     "1. Its trace must be equal to one: \n",
     "\n",
-    "    Remembering that the [trace of a matrix](https://en.wikipedia.org/wiki/Trace_(linear_algebra)) (denoted as $\\text{Tr}$) is the sum of its diagonal terms, we have:\n",
+    "    Remembering that the [trace of a matrix](https://en.wikipedia.org/wiki/Trace_%28linear_algebra%29) (denoted as $\\text{Tr}$) is the sum of its diagonal terms, we have:\n",
     "\n",
     "    $$ \\text{Tr}(\\rho) =\\sum_{k} \\rho_{kk} = \\sum_{k} \\sum_{j} p_j |\\alpha_{k}^{(j)} |^{2} = \\sum_{j} p_j \\sum_{k} |\\alpha_{k}^{(j)} |^{2} = 1\n",
     "    $$\n",
@@ -23297,7 +23297,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -23311,7 +23311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.10.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/content/ch-quantum-hardware/density-matrix.ipynb
+++ b/content/ch-quantum-hardware/density-matrix.ipynb
@@ -3143,7 +3143,7 @@
     "\n",
     "1. Its trace must be equal to one: \n",
     "\n",
-    "    Remembering that the [trace of a matrix](https://en.wikipedia.org/wiki/Trace_%28linear_algebra%29) (denoted as $\\text{Tr}$) is the sum of its diagonal terms, we have:\n",
+    "    Remembering that the <a href=\"https://en.wikipedia.org/wiki/Trace_(linear_algebra)\">trace of a matrix</a> (denoted as $\\text{Tr}$) is the sum of its diagonal terms, we have:\n",
     "\n",
     "    $$ \\text{Tr}(\\rho) =\\sum_{k} \\rho_{kk} = \\sum_{k} \\sum_{j} p_j |\\alpha_{k}^{(j)} |^{2} = \\sum_{j} p_j \\sum_{k} |\\alpha_{k}^{(j)} |^{2} = 1\n",
     "    $$\n",

--- a/content/ch-quantum-hardware/density-matrix.ipynb
+++ b/content/ch-quantum-hardware/density-matrix.ipynb
@@ -23297,7 +23297,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -23311,7 +23311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
+   "version": "3.7.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
This PR is for solving issue #1453 
# Changes made
Changed the link to trace on Wikipedia in section [Trace and Positivity Conditions](https://qiskit.org/textbook/ch-quantum-hardware/density-matrix.html#Trace-and-Positivity-Conditions-) to eliminate extra ')'. 

# Justification
There is an extra ')' after the link to Wikipedia which needs to be eliminated. It was due to '(' and ')' in the link to Wikipedia. I encoded them with '%28' for '(' and '%29' for '('.