### PR TITLE
[What is Quantum?] off-by-one in coin toss simulator

### DIFF
--- a/content/what-is-quantum.ipynb
+++ b/content/what-is-quantum.ipynb
@@ -200,7 +200,7 @@
     "\n",
     "# Define buttons and sliders\n",
     "tossbtn = Button(label=\"Toss Coin\")\n",
-    "repeat_slider = Slider(title=\"No. of Coins\", start=1, end=50, step=1, value=0)\n",
+    "repeat_slider = Slider(title=\"No. of Coins\", start=1, end=50, step=1, value=1)\n",
     "radio_label = Div(text=\"Initial State:\")\n",
     "init_state_radio = RadioButtonGroup(name=\"Initial State\", labels=data_labels, active=0)\n",
     "resetbtn = Button(label=\"Reset\")\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Changed the value of the `value` attribute of `repeat_slider` function in the "Experiment 1" from `0` to `1`.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

Fixed the issue #1512 
>>While tossing the coin with the simulator, the initial no: of coin/s is set to 0, which is obscured, and the simulator goes on to toss '0' coin/s and still gives a result, which in reality should not be the case.  

Changed it to be 1.
