### PR TITLE
Chapter [3] Section [3.8] Fixed the error of |s> to |s'>

### DIFF
--- a/content/ch-algorithms/grover.ipynb
+++ b/content/ch-algorithms/grover.ipynb
@@ -230,7 +230,7 @@
     "![image6](images/grover_circuit_2qbuits_oracle_11.svg)\n",
     "\n",
     "#### Reflection $U_s$\n",
-    "In order to complete the circuit we need to implement the additional reflection $U_s = 2|s\\rangle\\langle s| - I$. Since this is a reflection about $|s\\rangle$, we want to add a negative phase to every state orthogonal to $|s\\rangle$. \n",
+    "In order to complete the circuit we need to implement the additional reflection $U_s = 2|s\\rangle\\langle s| - I$. Since this is a reflection about $|s^{\prime}\\rangle$, we want to add a negative phase to every state orthogonal to $|s^{\prime}\\rangle$. \n",
     "\n",
     "One way we can do this is to use the operation that transforms the state $|s\\rangle \\rightarrow |0\\rangle$, which we already know is the Hadamard gate applied to each qubit:\n",
     "\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Addressed the Issue #1515 

Changed the "reflections about |s>" to "reflections about |s'>" and also the "perpendicular to |s>" to "perpendicular to |s'>"

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->

In the grover's algorithm, the two orthogonal states are the winner state |w> and the superposition state excluding the winner state i.e |s'>.
So the reflection is of the superposition state |s> about the perpendicular state |s'>.



# Issues
Anytime I propose the change the file just crashes and returns an Error of the page not being found.
[This](https://github.com/qiskit-community/qiskit-textbook/blob/main/content/ch-algorithms/grover.ipynb) is the file I'm trying to correct.  
