### PR TITLE
Migrate ruby action

### DIFF
--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7.7
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.7
         
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.x
 


### PR DESCRIPTION
The build / deploy is failing as the ruby setup action is deprecated. The deprecation notice recommends migrating to `ruby/setup-ruby@v1`, which is what I've done here.
