### PR TITLE
[1.3] Fixed save_statevector() error representing-qubit-states.ipynb

### DIFF
--- a/content/ch-states/representing-qubit-states.ipynb
+++ b/content/ch-states/representing-qubit-states.ipynb
@@ -152,7 +152,8 @@
    "source": [
     "from qiskit import QuantumCircuit, assemble, Aer\n",
     "from qiskit.visualization import plot_histogram, plot_bloch_vector\n",
-    "from math import sqrt, pi"
+    "from math import sqrt, pi\n"
+    "from qiskit.providers.aer import Aer"
    ]
   },
   {


### PR DESCRIPTION

# Changes made
Added code to import Aer explicitly from qiskit.providers.aer

# Justification
Was unable to apply the save_statevector instruction to a newly created QuantumCircuit. Doing so throws an error: AttributeError: 'QuantumCircuit' object has no attribute 'save_statevector'. 
