### PR TITLE
[1.4] Article change for grammatical correctness: changed 'an' to 'a'. 

### DIFF
--- a/content/ch-states/single-qubit-gates.ipynb
+++ b/content/ch-states/single-qubit-gates.ipynb
@@ -661,7 +661,7 @@
    "metadata": {},
    "source": [
     "### 6.3 The T-gate <a id=\"tgate\"></a>\n",
-    "The T-gate is a very commonly used gate, it is an P-gate with $\\phi = \\pi/4$:\n",
+    "The T-gate is a very commonly used gate, it is a P-gate with $\\phi = \\pi/4$:\n",
     "\n",
     "$$ T = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{\\frac{i\\pi}{4}} \\end{bmatrix}, \\quad  T^\\dagger = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{-\\frac{i\\pi}{4}} \\end{bmatrix}$$\n",
     "\n",


### PR DESCRIPTION
<!--- 
The T-Gate [6.3] in Quantum States and Qubits: Single Qubit Gates [Ch. 1.4]

--->
# Changes made
Changed article in "The T-gate is a very commonly used gate, it is an P-gate with $\\phi = \\pi/4$" to 
"The T-gate is a very commonly used gate, it is a P-gate with $\\phi = \\pi/4$"

# Justification
"an P-gate" should be "a P-gate" to agree with English article rules. Since the starting letter, 'p-', in p-gate (phase gate) is a consonant that is not silent, 'a' would be the correct article.