### PR TITLE
[5.4] Correcting typo on the definition of m'

### DIFF
--- a/content/ch-quantum-hardware/measuring-quantum-volume.ipynb
+++ b/content/ch-quantum-hardware/measuring-quantum-volume.ipynb
@@ -64,7 +64,7 @@
     "$$ U^{(t)} = U^{(t)}_{\\pi_t(m'-1),\\pi_t(m)} \\otimes ... \\otimes U^{(t)}_{\\pi_t(1),\\pi_t(2)} $$\n",
     "\n",
     "\n",
-    "each labeled by times $t = 1 ... d$ and acting on $m' = 2 \\lfloor n/2 \\rfloor$ qubits. \n",
+    "each labeled by times $t = 1 ... d$ and acting on $m' = 2 \\lfloor m/2 \\rfloor$ qubits. \n",
     "Each layer is specified by choosing a uniformly random permutation $\\pi_t \\in S_m$ of the $m$ qubit indices\n",
     "and sampling each $U^{(t)}_{a,b}$, acting on qubits $a$ and $b$, from the Haar measure on $SU(4)$.\n",
     "\n",


### PR DESCRIPTION
# Changes made
Changed the definition of m' so that it is expressed in fonction of m instead of n

# Justification
m' should be equal 2*[m/2], thus expressing m' = m if m is even ; m' = m - 1 if m is odd. The term n of the current version appears out of nowhere.
