### PR TITLE
[3.9] Fix qft function

### DIFF
--- a/content/ch-algorithms/quantum-counting.ipynb
+++ b/content/ch-algorithms/quantum-counting.ipynb
@@ -249,7 +249,7 @@
    "source": [
     "def qft(n):\n",
     "    \"\"\"Creates an n-qubit QFT circuit\"\"\"\n",
-    "    circuit = QuantumCircuit(4)\n",
+    "    circuit = QuantumCircuit(n)\n",
     "    def swap_registers(circuit, n):\n",
     "        for qubit in range(n//2):\n",
     "            circuit.swap(qubit, n-qubit-1)\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Fix the `qft` function to work for n != 4 

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
If someone wants to vary the number of counting qubits, the function fails. Note that simply varying `t` a few cells below still does not work due to the hardcoded 4 in this cell:

```
qft_dagger = qft(4).to_gate().inverse()
qft_dagger.label = "QFT†"
```

although generalising to use the `t` variable instead would require some re-ordering.
