### PR TITLE
Fix a typo #3

### DIFF
--- a/content/ch-algorithms/quantum-counting.ipynb
+++ b/content/ch-algorithms/quantum-counting.ipynb
@@ -3366,7 +3366,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may remember that we can get the angle $\\theta/2$ can from the inner product of $|s\\rangle$ and $|s’\\rangle$:\n",
+    "You may remember that we can get the angle $\\theta/2$ from the inner product of $|s\\rangle$ and $|s’\\rangle$:\n",
     "\n",
     "![image3](images/quantum_counting3.svg)\n",
     "\n",


### PR DESCRIPTION
Remove a duplicate `can` in the sentence.

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->
# Changes made
<!--- Please state what you did --->
Fix a duplicating `can` word in the sentence
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
Correct sentence