### PR TITLE
Fixes_composing_problem_issue 

### DIFF
--- a/content/ch-algorithms/deutsch-jozsa.ipynb
+++ b/content/ch-algorithms/deutsch-jozsa.ipynb
@@ -3231,7 +3231,7 @@
     "dj_circuit.h(n)\n",
     "\n",
     "# Add oracle\n",
-    "dj_circuit += balanced_oracle\n",
+    "dj_circuit &= balanced_oracle\n",
     "dj_circuit.draw()"
    ]
   },
@@ -4182,7 +4182,7 @@
     "dj_circuit.h(n)\n",
     "\n",
     "# Add oracle\n",
-    "dj_circuit += balanced_oracle\n",
+    "dj_circuit &= balanced_oracle\n",
     "\n",
     "# Repeat H-gates\n",
     "for qubit in range(n):\n",


### PR DESCRIPTION
<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "[4.5, 6.3] Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.

If you are contributing any new content, you must link the issue you
created beforehand by typing "Resolves #issue-number"
--->fixes #1562 
# Changes made
<!--- Please state what you did --->
The problem which is reported is due to depreciation due to removal of `extend` method.

# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not assume the justification is obvious --->
Found this in release notes     



The [`QuantumCircuit`](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit) methods `combine` and `extend` have been removed following their deprecation in Qiskit Terra 0.17.0. This was done because these functions were simply less powerful versions of [`QuantumCircuit.compose()`](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.compose.html#qiskit.circuit.QuantumCircuit.compose), which should be used instead.

The removal of `extend` also means that the `+` and `+=` operators are no longer defined for [`QuantumCircuit`](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit). Instead, you can use the `&` and `&=` operators respectively, which use [`QuantumCircuit.compose()`](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.compose.html#qiskit.circuit.QuantumCircuit.compose).


