### PR TITLE
Update banner message

### DIFF
--- a/_data/ja/messages.yml
+++ b/_data/ja/messages.yml
@@ -13,5 +13,7 @@ nav_community: Community
 nav_learn: Learn
 
 beta_testing: Try the new textbook beta
-beta_available: The new Qiskit Textbook beta is now available.
-try_now: Try it out now
+
+deprecation_warning_1: On April 11, this site will be replaced with the new
+deprecation_warning_link_text: Qiskit Textbook
+deprecation_warning_2: You will still be able to access these pages through the new platform.

--- a/_data/messages.yml
+++ b/_data/messages.yml
@@ -13,5 +13,7 @@ nav_community: Community
 nav_learn: Learn
 
 beta_testing: Try the new textbook beta
-beta_available: The new Qiskit Textbook beta is now available.
-try_now: Try it out now
+
+deprecation_warning_1: On April 11, this site will be replaced with the new
+deprecation_warning_link_text: Qiskit Textbook
+deprecation_warning_2: You will still be able to access these pages through the new platform.

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -5,8 +5,8 @@
 {% endif %}
 
 <div id="textbook-banner" class="page__banner">
-  {{ messages.beta_available }}
+  {{ messages.deprecation_warning_1 }}
   <a href="https://qiskit.org/textbook-beta" target="_blank">
-    {{ messages.try_now }}
-  </a>
+    {{ messages.deprecation_warning_link_text }}</a>.
+  {{ messages.deprecation_warning_2 }}
 </div>


### PR DESCRIPTION
# Changes made

Updates the banner to warn about deprecation of the legacy textbook website.

**Message:**

> On April 11, this site will be replaced with the new[ Qiskit Textbook](https://qiskit.org/textbook-beta). You will still be able to access these pages through the new platform.

![Screenshot 2023-04-06 at 18 15 36](https://user-images.githubusercontent.com/36071638/230449585-5c96c35f-db80-4c3c-9308-c8cb7d0adac4.png)
